### PR TITLE
Automatically import vstd and builtin

### DIFF
--- a/crates/base-db/src/fixture.rs
+++ b/crates/base-db/src/fixture.rs
@@ -409,6 +409,9 @@ fn parse_crate(crate_str: String) -> (String, CrateOrigin, Option<String>) {
         let crate_origin = match &*crate_str {
             "std" => CrateOrigin::Lang(LangCrateOrigin::Std),
             "core" => CrateOrigin::Lang(LangCrateOrigin::Core),
+            "vstd" => CrateOrigin::Lang(LangCrateOrigin::Vstd),             // Verus 
+            "builtin" => CrateOrigin::Lang(LangCrateOrigin::Builtin),       // Verus 
+            // "builtin_macros" => CrateOrigin::Lang(LangCrateOrigin::BuiltinMacros),  // Verus 
             _ => CrateOrigin::CratesIo { repo: None },
         };
         (crate_str, crate_origin, None)

--- a/crates/base-db/src/input.rs
+++ b/crates/base-db/src/input.rs
@@ -137,7 +137,7 @@ impl ops::Deref for CrateName {
 pub enum CrateOrigin {
     /// Crates that are from crates.io official registry,
     CratesIo { repo: Option<String> },
-    /// Crates that are provided by the language, like std, core, proc-macro, ...
+    /// Crates that are provided by the language, like std, core, proc-macro, ...   (Verus: vstd, builtin, builtin_macros)
     Lang(LangCrateOrigin),
 }
 
@@ -147,6 +147,9 @@ pub enum LangCrateOrigin {
     Core,
     ProcMacro,
     Std,
+    Vstd,         // Verus 
+    Builtin,      // Verus 
+    // BuiltinMacros, // Verus
     Test,
     Other,
 }
@@ -158,6 +161,9 @@ impl From<&str> for LangCrateOrigin {
             "core" => LangCrateOrigin::Core,
             "proc-macro" => LangCrateOrigin::ProcMacro,
             "std" => LangCrateOrigin::Std,
+            "vstd" => LangCrateOrigin::Vstd,                        // Verus 
+            "builtin" => LangCrateOrigin::Builtin,                  // Verus 
+            // "builtin_macros" => LangCrateOrigin::BuiltinMacros,     // Verus 
             "test" => LangCrateOrigin::Test,
             _ => LangCrateOrigin::Other,
         }
@@ -171,6 +177,9 @@ impl fmt::Display for LangCrateOrigin {
             LangCrateOrigin::Core => "core",
             LangCrateOrigin::ProcMacro => "proc_macro",
             LangCrateOrigin::Std => "std",
+            LangCrateOrigin::Vstd => "vstd",                        // Verus 
+            LangCrateOrigin::Builtin => "builtin",                  // Verus 
+            // LangCrateOrigin::BuiltinMacros => "builtin_macros",     // Verus 
             LangCrateOrigin::Test => "test",
             LangCrateOrigin::Other => "other",
         };

--- a/crates/ide-db/src/famous_defs.rs
+++ b/crates/ide-db/src/famous_defs.rs
@@ -25,6 +25,11 @@ impl FamousDefs<'_, '_> {
     pub fn std(&self) -> Option<Crate> {
         self.find_lang_crate(LangCrateOrigin::Std)
     }
+    
+    // Verus 
+    pub fn vstd(&self) -> Option<Crate> {
+        self.find_lang_crate(LangCrateOrigin::Vstd)
+    }
 
     pub fn core(&self) -> Option<Crate> {
         self.find_lang_crate(LangCrateOrigin::Core)
@@ -109,6 +114,7 @@ impl FamousDefs<'_, '_> {
     pub fn builtin_crates(&self) -> impl Iterator<Item = Crate> {
         IntoIterator::into_iter([
             self.std(),
+            self.vstd(),// Verus 
             self.core(),
             self.alloc(),
             self.test(),

--- a/crates/project-model/src/cargo_workspace.rs
+++ b/crates/project-model/src/cargo_workspace.rs
@@ -90,6 +90,7 @@ pub struct CargoConfig {
     pub no_sysroot: bool,
 
     // TODO(verus): import verus pervasive from "config"
+    pub verus_root: Option<String>,
 
     /// rustc private crate source
     pub rustc_source: Option<RustcSource>,

--- a/crates/project-model/src/project_json.rs
+++ b/crates/project-model/src/project_json.rs
@@ -21,6 +21,8 @@ pub struct ProjectJson {
     pub(crate) sysroot: Option<AbsPathBuf>,
     /// e.g. `path/to/sysroot/lib/rustlib/src/rust`
     pub(crate) sysroot_src: Option<AbsPathBuf>,
+    // verus root path
+    // pub(crate) verus_root: Option<AbsPathBuf>,
     project_root: AbsPathBuf,
     crates: Vec<Crate>,
 }
@@ -57,6 +59,7 @@ impl ProjectJson {
         ProjectJson {
             sysroot: data.sysroot.map(|it| base.join(it)),
             sysroot_src: data.sysroot_src.map(|it| base.join(it)),
+            // verus_root: data.verus_root.map_or(None, |v| AbsPathBuf::try_from(v).ok()),
             project_root: base.to_path_buf(),
             crates: data
                 .crates
@@ -128,6 +131,7 @@ impl ProjectJson {
 pub struct ProjectJsonData {
     sysroot: Option<PathBuf>,
     sysroot_src: Option<PathBuf>,
+    // verus_root: Option<PathBuf>,
     crates: Vec<CrateData>,
 }
 

--- a/crates/project-model/src/sysroot.rs
+++ b/crates/project-model/src/sysroot.rs
@@ -53,7 +53,7 @@ impl Sysroot {
     pub fn public_deps(&self) -> impl Iterator<Item = (&'static str, SysrootCrate, bool)> + '_ {
         // core is added as a dependency before std in order to
         // mimic rustcs dependency order
-        ["core", "alloc", "std", "vstd", "builtin", "builtin_macros"]   // Verus 
+        ["core", "alloc", "std", "vstd", "builtin"]   // Verus 
             .into_iter()
             .zip(iter::repeat(true))
             .chain(iter::once(("test", false)))
@@ -82,6 +82,7 @@ impl Sysroot {
         discover_sysroot_dir(current_dir).ok().and_then(|sysroot_dir| get_rustc_src(&sysroot_dir))
     }
 
+    // add one argument about "verus_root_directory"
     pub fn load(sysroot_dir: AbsPathBuf, sysroot_src_dir: AbsPathBuf) -> Result<Sysroot> {
         let mut sysroot =
             Sysroot { root: sysroot_dir, src_root: sysroot_src_dir, crates: Arena::default() };
@@ -108,7 +109,7 @@ impl Sysroot {
                 let mut vstd_path = format!("/Users/chanhee/Works/secure-foundations/verus/source/{}/src/lib.rs", name);
                 if name == "vstd" {
                     // tmp
-                    vstd_path = "/Users/chanhee/Works/secure-foundations/verus/source/pervasive/vstd.rs".to_string();
+                    vstd_path = "/Users/chanhee/Works/secure-foundations/verus/source/pervasive/mod.rs".to_string();
                 }
                 dbg!(&vstd_path);
                 let pathb = PathBuf::from_str(vstd_path.as_str()).unwrap();

--- a/crates/project-model/src/tests.rs
+++ b/crates/project-model/src/tests.rs
@@ -80,7 +80,7 @@ fn get_fake_sysroot() -> Sysroot {
     // fake sysroot, so we give them both the same path:
     let sysroot_dir = AbsPathBuf::assert(sysroot_path);
     let sysroot_src_dir = sysroot_dir.clone();
-    Sysroot::load(sysroot_dir, sysroot_src_dir).unwrap()
+    Sysroot::load(sysroot_dir, sysroot_src_dir, None).unwrap()
 }
 
 fn rooted_project_json(data: ProjectJsonData) -> ProjectJson {

--- a/crates/project-model/src/workspace.rs
+++ b/crates/project-model/src/workspace.rs
@@ -639,6 +639,7 @@ fn cargo_to_crate_graph(
         }
 
         // Set deps to the core, std and to the lib target of the current package
+        // Verus(add vstd?)
         for (from, kind) in pkg_crates.get(&pkg).into_iter().flatten() {
             // Add sysroot deps first so that a lib target named `core` etc. can overwrite them.
             public_deps.add(*from, &mut crate_graph);
@@ -816,6 +817,7 @@ fn handle_rustc_crates(
                     );
                     pkg_to_lib_crate.insert(pkg, crate_id);
                     // Add dependencies on core / std / alloc for this crate
+                    // Verus(add vstd(pervasive)?)
                     public_deps.add(crate_id, crate_graph);
                     rustc_pkg_crates.entry(pkg).or_insert_with(Vec::new).push(crate_id);
                 }


### PR DESCRIPTION
This PR is to automatically import Verus' vstd(verified std) and builtin without the user's guide.

Currently Verus uses "pervasive" which will be replaced by "vstd", and we have the user to generated a symlink to the pervasive in the project's "src" directory. This was because "pervasive" was a module rather than a crate. As vstd becomes a separate crate, this PR changes verus-analyzer to index vstd crate when it index std crate in the startup.

