### PR TITLE
Replacing CargoHandle with CommandHandle and some fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,7 +119,7 @@ Please set only one of `rust-analyzer.checkOnSave.overrideCommand` and `rust-ana
 ## Functionalities and Details
 
 ### 1.Syntax
-We extended rust-analyzer's grammar for Verus-specific syntax. This custom rust-analyzer highlights reserved Verus keywords (e.g., `spec`, `proof`, `requires`, `ensures`). If a user types `prooof` instead of `proof`, a syntax error will be generated for it.
+We extended rust-analyzer's grammar for Verus-specific syntax. This custom rust-analyzer highlights reserved Verus keywords (e.g., `spec`, `proof`, `requires`, `ensures`). If a user types `proof` instead of `proof`, a syntax error will be generated for it.
 
 
 ### 2.IDE functionalities
@@ -130,7 +130,7 @@ You can find more documents for IDE functionalities on the following links.
 - [Hover](https://rust-analyzer.github.io/manual.html#hover)
 
 #### 2.1 TODOs for IDE functionalities
-- Code scanning is incomplete for Verus-specific items. To be specific, requires/ensures/decreases/invariant/assert-by-block/assert-forall-block are not fully scanned for IDE purposes.(e.g., might not be able to "goto definition" of the function used in requires/ensures, "find all references" might omit occurences inside requires/ensures)
+- Code scanning is incomplete for Verus-specific items. To be specific, requires/ensures/decreases/invariant/assert-by-block/assert-forall-block are not fully scanned for IDE purposes.(e.g., might not be able to "goto definition" of the function used in requires/ensures, "find all references" might omit occurrences inside requires/ensures)
 
 - Although Verus' custom operators are parsed, those are not registered for IDE purposes. For example, type inference around those operators might not work. (e.g., `A ==> B` is parsed as `implies(A, B)`, but the IDE might not be able to infer that `A` and `B` are boolean)
 

--- a/crates/flycheck/src/lib.rs
+++ b/crates/flycheck/src/lib.rs
@@ -362,7 +362,7 @@ impl FlycheckActor {
                                 "Started running the following Verus command: {:?}",
                                 self.run_verus(filename),
                             )));
-                            self.report_progress(Progress::DidStart); // this is important -- otherewise, previous diagnostic does not disappear
+                            self.report_progress(Progress::DidStart); // this is important -- otherwise, previous diagnostic does not disappear
                             self.status = FlycheckStatus::Started;
                         }
                         Err(error) => {

--- a/crates/flycheck/src/lib.rs
+++ b/crates/flycheck/src/lib.rs
@@ -11,7 +11,7 @@
 use std::{
     fmt, io,
     path::Path,
-    process::{Child, ChildStderr, ChildStdout, Command, Stdio},
+    process::Command,
     time::Duration,
 };
 
@@ -241,13 +241,6 @@ struct FlycheckActor {
     command_receiver: Option<Receiver<CargoCheckMessage>>,
 
     status: FlycheckStatus,
-
-    /// CargoHandle exists to wrap around the communication needed to be able to
-    /// run `cargo check` without blocking. Currently the Rust standard library
-    /// doesn't provide a way to read sub-process output without blocking, so we
-    /// have to wrap sub-processes output handling in a thread and pass messages
-    /// back over a channel.
-    cargo_handle: Option<CargoHandle>,
 }
 
 enum Event {
@@ -284,7 +277,6 @@ impl FlycheckActor {
             command_handle: None,
             command_receiver: None,
             status: FlycheckStatus::Finished,
-            cargo_handle: None,
         }
     }
 
@@ -357,23 +349,27 @@ impl FlycheckActor {
                     }
 
                     let command = self.run_verus(filename.clone());
-                    match CargoHandle::spawn(command) {
-                        Ok(cargo_handle) => {
+                    let formatted_command = format!("{command:?}");
+                    tracing::debug!(?command, "will restart flycheck");
+                    let (sender, receiver) = unbounded();
+                    match CommandHandle::spawn(command, sender) {
+                        Ok(command_handle) => {
                             tracing::error!("did  restart Verus");
+                            self.command_handle = Some(command_handle);
+                            self.command_receiver = Some(receiver);
 
-                            self.cargo_handle = Some(cargo_handle);
                             self.report_progress(Progress::VerusResult(format!(
                                 "Started running the following Verus command: {:?}",
                                 self.run_verus(filename),
                             )));
                             self.report_progress(Progress::DidStart); // this is important -- otherewise, previous diagnostic does not disappear
+                            self.status = FlycheckStatus::Started;
                         }
                         Err(error) => {
-                            self.report_progress(Progress::VerusResult(format!(
-                                "Failed to run the following Verus command: {:?} error={}",
-                                self.run_verus(filename),
-                                error
+                            self.report_progress(Progress::DidFailToRestart(format!(
+                                "Failed to run the following command: {formatted_command} error={error}"
                             )));
+                            self.status = FlycheckStatus::Finished;
                         }
                     }
                 }
@@ -673,153 +669,7 @@ impl FlycheckActor {
     }
 }
 
-struct JodChild(Child);
 
-impl Drop for JodChild {
-    fn drop(&mut self) {
-        _ = self.0.kill();
-        _ = self.0.wait();
-    }
-}
-
-/// A handle to a cargo process used for fly-checking.
-struct CargoHandle {
-    /// The handle to the actual cargo process. As we cannot cancel directly from with
-    /// a read syscall dropping and therefore terminating the process is our best option.
-    child: JodChild,
-    thread: stdx::thread::JoinHandle<io::Result<(bool, String)>>,
-    receiver: Receiver<CargoCheckMessage>,
-}
-
-impl CargoHandle {
-    fn spawn(mut command: Command) -> std::io::Result<CargoHandle> {
-        dbg!("spawn from CargoHandle");
-        command.stdout(Stdio::piped()).stderr(Stdio::piped()).stdin(Stdio::null());
-        let mut child = command.spawn().map(JodChild)?;
-        dbg!("finished executing command");
-
-        let stdout = child.0.stdout.take().unwrap();
-        let stderr = child.0.stderr.take().unwrap();
-
-        let (sender, receiver) = unbounded();
-        let actor = CargoActor::new(sender, stdout, stderr);
-        let thread = stdx::thread::Builder::new(stdx::thread::ThreadIntent::Worker)
-            .name("CargoHandle".to_owned())
-            .spawn(move || actor.run())
-            .expect("failed to spawn thread");
-        Ok(CargoHandle { child, thread, receiver })
-    }
-
-    fn cancel(mut self) {
-        let _ = self.child.0.kill();
-        let _ = self.child.0.wait();
-    }
-
-    fn join(mut self) -> io::Result<()> {
-        let _ = self.child.0.kill();
-        let exit_status = self.child.0.wait()?;
-        let (read_at_least_one_message, error) = self.thread.join()?;
-        if read_at_least_one_message || exit_status.success() {
-            Ok(())
-        } else {
-            Err(io::Error::new(io::ErrorKind::Other, format!(
-                "Cargo watcher failed, the command produced no valid metadata (exit code: {exit_status:?}):\n{error}"
-            )))
-        }
-    }
-}
-
-struct CargoActor {
-    sender: Sender<CargoCheckMessage>,
-    stdout: ChildStdout,
-    stderr: ChildStderr,
-}
-
-impl CargoActor {
-    fn new(
-        sender: Sender<CargoCheckMessage>,
-        stdout: ChildStdout,
-        stderr: ChildStderr,
-    ) -> CargoActor {
-        CargoActor { sender, stdout, stderr }
-    }
-
-    fn run(self) -> io::Result<(bool, String)> {
-        // We manually read a line at a time, instead of using serde's
-        // stream deserializers, because the deserializer cannot recover
-        // from an error, resulting in it getting stuck, because we try to
-        // be resilient against failures.
-        //
-        // Because cargo only outputs one JSON object per line, we can
-        // simply skip a line if it doesn't parse, which just ignores any
-        // erroneous output.
-
-        let mut stdout_errors = String::new();
-        let mut stderr_errors = String::new();
-        let mut read_at_least_one_stdout_message = false;
-        let mut read_at_least_one_stderr_message = false;
-        let process_line = |line: &str, error: &mut String| {
-            // Try to deserialize a message from Cargo or Rustc.
-            let mut deserializer = serde_json::Deserializer::from_str(line);
-            deserializer.disable_recursion_limit();
-            if let Ok(message) = JsonMessage::deserialize(&mut deserializer) {
-                match message {
-                    // Skip certain kinds of messages to only spend time on what's useful
-                    JsonMessage::Cargo(message) => match message {
-                        cargo_metadata::Message::CompilerArtifact(artifact) if !artifact.fresh => {
-                            self.sender
-                                .send(CargoCheckMessage::CompilerArtifact(artifact))
-                                .unwrap();
-                        }
-                        cargo_metadata::Message::CompilerMessage(msg) => {
-                            self.sender.send(CargoCheckMessage::Diagnostic(msg.message)).unwrap();
-                        }
-                        _ => (),
-                    },
-                    JsonMessage::Rustc(message) => {
-                        self.sender.send(CargoCheckMessage::Diagnostic(message)).unwrap();
-                    }
-                }
-                return true;
-            } else {
-                // verus
-                // forward verification result
-                tracing::error!("deserialize error: {:?}", line);
-                if line.contains("verification results::") {
-                    self.sender.send(CargoCheckMessage::VerusResult(line.to_string())).unwrap();
-                }
-            }
-
-            error.push_str(line);
-            error.push('\n');
-            false
-        };
-        let output = stdx::process::streaming_output(
-            self.stdout,
-            self.stderr,
-            &mut |line| {
-                if process_line(line, &mut stdout_errors) {
-                    read_at_least_one_stdout_message = true;
-                }
-            },
-            &mut |line| {
-                if process_line(line, &mut stderr_errors) {
-                    read_at_least_one_stderr_message = true;
-                }
-            },
-            &mut || {},
-        );
-
-        let read_at_least_one_message =
-            read_at_least_one_stdout_message || read_at_least_one_stderr_message;
-        let mut error: String = stdout_errors;
-        error.push_str(&stderr_errors);
-        match output {
-            Ok(_) => Ok((read_at_least_one_message, error)),
-            Err(e) => Err(io::Error::new(e.kind(), format!("{e:?}: {error}"))),
-        }
-    }
-}
 
 #[allow(clippy::large_enum_variant)]
 enum CargoCheckMessage {
@@ -846,6 +696,13 @@ impl ParseFromLine for CargoCheckMessage {
                 },
                 JsonMessage::Rustc(message) => Some(CargoCheckMessage::Diagnostic(message)),
             };
+        } else {
+            // verus
+            // forward verification result
+            tracing::error!("deserialize error: {:?}", line);
+            if line.contains("verification results::") {
+                Some(CargoCheckMessage::VerusResult(line.to_string()));
+            }
         }
 
         error.push_str(line);

--- a/crates/hir-def/src/item_tree.rs
+++ b/crates/hir-def/src/item_tree.rs
@@ -1114,7 +1114,7 @@ impl AssocItem {
             AssocItem::TypeAlias(id) => tree[id].ast_id.upcast(),
             AssocItem::Const(id) => tree[id].ast_id.upcast(),
             AssocItem::MacroCall(id) => tree[id].ast_id.upcast(),
-            AssocItem::VerusGlobal(id) => todo!(), // tree[id].ast_id.upcast(),
+            AssocItem::VerusGlobal(_id) => todo!(), // tree[id].ast_id.upcast(),
         }
     }
 }

--- a/crates/hir-def/src/item_tree/pretty.rs
+++ b/crates/hir-def/src/item_tree/pretty.rs
@@ -11,7 +11,7 @@ use crate::{
         FileItemTreeId, FnFlags, Function, GenericModItem, GenericParams, Impl, Interned, ItemTree,
         Macro2, MacroCall, MacroRules, Mod, ModItem, ModKind, Param, ParamAstId, Path, RawAttrs,
         RawVisibilityId, Static, Struct, Trait, TraitAlias, TypeAlias, TypeBound, TypeRef, Union,
-        Use, UseTree, UseTreeKind, Variant, VerusGlobal,
+        Use, UseTree, UseTreeKind, Variant,
     },
     pretty::{print_path, print_type_bounds, print_type_ref},
     visibility::RawVisibility,
@@ -508,7 +508,7 @@ impl Printer<'_> {
                 self.print_visibility(*visibility);
                 wln!(self, "macro {} {{ ... }}", name.display(self.db.upcast()));
             }
-            ModItem::VerusGlobal(it) => {
+            ModItem::VerusGlobal(_it) => {
                 // let VerusGlobal { ast_id } = &self.tree[it];
                 // self.print_ast_id(ast_id.erase());
                 wln!(self, "global ?? TODO!");

--- a/crates/ide-assists/src/handlers/proof_action/apply_induction.rs
+++ b/crates/ide-assists/src/handlers/proof_action/apply_induction.rs
@@ -48,7 +48,7 @@ pub(crate) fn apply_induction(acc: &mut Assists, ctx: &AssistContext<'_>) -> Opt
         }
     }
 
-    // now check if proof now goes thorugh, and make sure it is fast
+    // now check if proof now goes through, and make sure it is fast
     new_fn.body = Some(Box::new(result.clone()));
     let verif_result = ctx.try_verus(&new_fn)?;
     if !verif_result.is_success || verif_result.time > 10 {
@@ -126,7 +126,7 @@ fn apply_induction_on_enum(
                     .iter()
                     .filter(|f| {
                         f.ty.as_ref()
-                            .map_or_else(|| "{unkonwn}".to_string(), |x| x.to_string())
+                            .map_or_else(|| "{unknown}".to_string(), |x| x.to_string())
                             .replace(" ", "")
                             == bty
                     })

--- a/crates/ide-assists/src/handlers/proof_action/remove_redundant_assertion.rs
+++ b/crates/ide-assists/src/handlers/proof_action/remove_redundant_assertion.rs
@@ -18,7 +18,7 @@ use syntax::{
 /// This proof action deletes assertions that are not necessary for the proof succeeds.
 /// It iterates the proof and collects assertions that are redundant
 /// This proof action invokes Verus potentially a large number of times.
-/// Therefore, it delays invoking Verus to the point where an user explictly invokes this proof action.
+/// Therefore, it delays invoking Verus to the point where an user explicitly invokes this proof action.
 /// However, it initially invokes Verus once, to check if the proof succeeds
 ///
 /// As proof actions usually automatically adds a bunch of "redundant" assertions
@@ -148,11 +148,11 @@ mod tests {
             remove_dead_assertions,
             "
 use vstd::prelude::*;
-pr$0oof fn foo(x: nat) 
-    ensures 
+pr$0oof fn foo(x: nat)
+    ensures
         x >= 0,
-{ 
-    assert(x >= 0); 
+{
+    assert(x >= 0);
 }
 
 fn main() {}
@@ -177,10 +177,10 @@ fn main() {}
             remove_dead_assertions,
             "
 use vstd::prelude::*;
-pr$0oof fn foo(x: nat) 
-    ensures 
+pr$0oof fn foo(x: nat)
+    ensures
         x >= 0,
-{ 
+{
     assert(x >= 0);
     assert(x + x >= 0);
     assert(x * x >= 0) by (nonlinear_arith);
@@ -242,7 +242,7 @@ use vstd::prelude::*;
 fn main() {}
 
 pr$0oof fn proof_index(a: u16, offset: u16)
-    requires    
+    requires
         offset < 16,
     ensures
         offset < 16,

--- a/crates/ide-assists/src/handlers/proof_action/weakest_pre_step.rs
+++ b/crates/ide-assists/src/handlers/proof_action/weakest_pre_step.rs
@@ -9,7 +9,7 @@ use syntax::{
 /*
 "Weakest Precondition Step" a.k.a. "Move up assertion"
 
-This proof action allows users to step thourgh an assertion through statements, utilizing the rules below.
+This proof action allows users to step through an assertion through statements, utilizing the rules below.
 
 Previous statement =
     | Let-binding(simple expression -- i.e., does not have any function call with ensures clause)
@@ -156,7 +156,7 @@ pub(crate) fn vst_rewriter_wp_move_assertion(
                                     pat,
                                     func_ret_type
                                         .ty
-                                        .map_or_else(|| "{unkonwn}".to_string(), |x| x.to_string())
+                                        .map_or_else(|| "{unknown}".to_string(), |x| x.to_string())
                                 )
                                 .as_ref(),
                             )?
@@ -173,7 +173,7 @@ pub(crate) fn vst_rewriter_wp_move_assertion(
             match new_stmt {
                 Some(new_stmt) => (new_stmt, true),
                 None => {
-                    // when `prev` is let-binding, do subsitution (replace `pat` with `init`)
+                    // when `prev` is let-binding, do substitution (replace `pat` with `init`)
                     let new_assert = vst_map_expr_visitor(assertion.clone(), &mut |e| {
                         // TODO: do proper usage check in semantic level instead of string match
                         // TODO: variable name shadowing

--- a/crates/ide-assists/src/proof_plumber_api/inline_function_api.rs
+++ b/crates/ide-assists/src/proof_plumber_api/inline_function_api.rs
@@ -1,7 +1,7 @@
 //! ProofPlumber API for inline
 //!
 //! Used for inlining a precondition at the callsite
-//! See `insert_failing_precondtion.rs` for usage.
+//! See `insert_failing_precondition.rs` for usage.
 //!
 //!
 

--- a/crates/ide-assists/src/proof_plumber_api/proof_action_context.rs
+++ b/crates/ide-assists/src/proof_plumber_api/proof_action_context.rs
@@ -65,17 +65,17 @@ impl<'a> AssistContext<'a> {
         filter_pre_failuires(&self.verus_errors)
     }
 
-    /// Gather every postcondition failrues
+    /// Gather every postcondition failure
     pub fn post_failures(&self) -> Vec<PostFailure> {
         filter_post_failuires(&self.verus_errors)
     }
 
-    /// From a Precondition Failure, retreive the TOST expression of the failing predicate
+    /// From a Precondition Failure, retrieve the TOST expression of the failing predicate
     pub fn expr_from_pre_failure(&self, pre: PreFailure) -> Option<vst::Expr> {
         self.find_node_at_given_range::<syntax::ast::Expr>(pre.failing_pre)?.try_into().ok()
     }
 
-    /// From a Postcondition Failure, retreive the TOST expression of the failing predicate
+    /// From a Postcondition Failure, retrieve the TOST expression of the failing predicate
     pub fn expr_from_post_failure(&self, post: PostFailure) -> Option<vst::Expr> {
         self.find_node_at_given_range::<syntax::ast::Expr>(post.failing_post)?.try_into().ok()
     }

--- a/crates/ide-assists/src/proof_plumber_api/run_verus.rs
+++ b/crates/ide-assists/src/proof_plumber_api/run_verus.rs
@@ -158,15 +158,15 @@ pub(crate) struct VerifResult {
 }
 
 impl VerifResult {
-    pub fn mk_success(time: u64) -> Self {
+    pub(crate) fn mk_success(time: u64) -> Self {
         VerifResult { is_success: true, stdout: String::new(), stderr: String::new(), time }
     }
 
-    pub fn mk_failure(stdout: String, stderr: String, time: u64) -> Self {
+    pub(crate) fn mk_failure(stdout: String, stderr: String, time: u64) -> Self {
         VerifResult { is_success: false, stdout, stderr, time }
     }
 
-    pub fn is_failing(&self, assertion: &vst::AssertExpr) -> bool {
+    pub(crate) fn is_failing(&self, assertion: &vst::AssertExpr) -> bool {
         if self.is_success {
             return false;
         }

--- a/crates/ide-assists/src/proof_plumber_api/verus_error.rs
+++ b/crates/ide-assists/src/proof_plumber_api/verus_error.rs
@@ -1,14 +1,14 @@
 //! Basic enum/struct/fn for Verus Errors
 //!
 //! These are used to represent various errors from the verifier
-//! There are three kinds: precondition Failure, postcondition failrue, assertion failure
+//! There are three kinds: precondition Failure, postcondition failure, assertion failure
 //!
 //! For further reference, see `crates/rust-analyzer/verus_interaction`
 //!
 
 use text_edit::TextRange;
 
-/// Verus Erros with three kinds: pre/post/assert
+/// Verus Errors with three kinds: pre/post/assert
 #[derive(Debug, Eq, PartialEq, Clone)]
 pub enum VerusError {
     Pre(PreFailure),
@@ -16,7 +16,7 @@ pub enum VerusError {
     Assert(AssertFailure),
 }
 
-/// Precondition Failrue contains
+/// Precondition Failure contains
 /// (1) the exact precondition that is failing
 /// (2) the callsite that invoked this failure
 #[derive(Debug, Eq, PartialEq, Clone)]
@@ -25,7 +25,7 @@ pub struct PreFailure {
     pub callsite: TextRange,
 }
 
-/// Postcondition failrue contains
+/// Postcondition failure contains
 /// (1) the exact postcondition that is failing
 /// (2) the error span from Verus
 #[derive(Debug, Eq, PartialEq, Clone)]
@@ -34,7 +34,7 @@ pub struct PostFailure {
     pub func_body: TextRange,
 }
 
-/// Assertion failrue contains
+/// Assertion failure contains
 /// the asserted predicate
 #[derive(Debug, Eq, PartialEq, Clone)]
 pub struct AssertFailure {

--- a/crates/parser/src/grammar/attributes.rs
+++ b/crates/parser/src/grammar/attributes.rs
@@ -24,7 +24,7 @@ fn attr(p: &mut Parser<'_>, inner: bool) {
     // However, the rust-analyzer parser does not have access to string's content.
     // Therefore, to make a new syntax kind (e.g. TriggerAttribute),
     // we need to register `trigger` as a reserved keyword.
-    // however, by registering `trigger` as a reserved keyworkd,
+    // however, by registering `trigger` as a reserved keyword,
     // single trigger attribute, which is `#[trigger]` becomes invalid syntax.
     // therefore, we just special-case `#[trigger]`
     if p.nth(1) == T![!] && p.nth(2) == T!['['] && p.nth(3) == T![trigger] {

--- a/crates/parser/src/grammar/verus.rs
+++ b/crates/parser/src/grammar/verus.rs
@@ -394,16 +394,16 @@ pub(crate) fn trigger_attribute(p: &mut Parser<'_>) -> CompletedMarker {
     m.complete(p, TRIGGER_ATTRIBUTE) // Review: just replace TRIGGER_ATTRIBUTE with ERROR  to avoid other parts of code indexing getting into trouble
 }
 
-pub(crate) fn global_clause(p: &mut Parser<'_>, m: Marker) {
-    println!("global_clause");
-    //global size_of usize == 8;
-    p.bump(T![global]);
-    // name(p);
-    // name(p);
-    p.expect(T![==]);
-    p.expect(INT_NUMBER);
-    p.expect(T![;]);
+// pub(crate) fn global_clause(p: &mut Parser<'_>, m: Marker) {
+//     println!("global_clause");
+//     //global size_of usize == 8;
+//     p.bump(T![global]);
+//     // name(p);
+//     // name(p);
+//     p.expect(T![==]);
+//     p.expect(INT_NUMBER);
+//     p.expect(T![;]);
 
-    m.complete(p, VERUS_GLOBAL);
-    todo!("are we ehre yet?")
-}
+//     m.complete(p, VERUS_GLOBAL);
+//     todo!("are we ehre yet?")
+// }

--- a/crates/syntax/rust.ungram
+++ b/crates/syntax/rust.ungram
@@ -496,7 +496,7 @@ MethodCallExpr =
 FieldExpr =
   Attr* Expr '.' NameRef
 
-// verus: forall, exsits
+// verus: forall, exists
 ClosureExpr =
   Attr* ('for' GenericParamList)? 'const'? 'static'? 'async'? 'move'? 'forall'? 'exists'? ParamList RetType? Attr*
   body:Expr

--- a/crates/syntax/src/ast/vst.rs
+++ b/crates/syntax/src/ast/vst.rs
@@ -374,7 +374,7 @@ impl std::fmt::Display for AssertExpr {
             s.push_str(token_ascii(&tmp));
             s.push_str(" ");
         }
-        // paranthesis around prover name
+        // parenthesis around prover name
         if let Some(it) = &self.name {
             s.push_str(" (");
             s.push_str(&it.to_string());

--- a/crates/syntax/src/lib.rs
+++ b/crates/syntax/src/lib.rs
@@ -1422,7 +1422,7 @@ proof fn dec0_decreases(a: int) {
 // However, the rust-analyzer parser does not have access to string's content.
 // Therefore, to make a new syntax kind (e.g. TriggerAttribute),
 // we need to register `trigger` as a reserved keyword.
-// however, by registering `trigger` as a reserved keyworkd,
+// however, by registering `trigger` as a reserved keyword,
 // single trigger attribute, which is `#[trigger]` becomes invalid syntax.
 // therefore, we just special-case `#[trigger]`
 #[test]

--- a/xtask/src/codegen/grammar/sourcegen_vst.rs
+++ b/xtask/src/codegen/grammar/sourcegen_vst.rs
@@ -112,7 +112,7 @@ pub(crate) fn generate_vst(_kinds: KindsSrc<'_>, grammar: &AstSrc) -> String {
         .collect_vec();
 
     // impl new for struct
-    // For Expr, we specify arguemtns with type bound using `into<Expr>`
+    // For Expr, we specify arguments with type bound using `into<Expr>`
     let impl_new_for_struct: Vec<_> = grammar
         .nodes
         .iter()


### PR DESCRIPTION
It seems that the upstream rust-analyzer removed the CargoHandle and replaced it with the CommandHandle struct. So we do the same when starting Verus from verus-analyzer. 

Plus we squash some of the warnings regarding dead code and unused variables etc. 