### PR TITLE
Handle ArrowExpr in lower_expr_as_place_without_adjust

### DIFF
--- a/crates/hir-ty/src/mir/lower/as_place.rs
+++ b/crates/hir-ty/src/mir/lower/as_place.rs
@@ -209,7 +209,7 @@ impl MirLowerCtx<'_> {
                 Ok(Some((r, current)))
             }
             Expr::UnaryOp { .. } => try_rvalue(self),
-            Expr::Field { expr, .. } => {
+            Expr::Field { expr, .. } | Expr::ArrowExpr { expr, .. } => {
                 let Some((mut r, current)) = self.lower_expr_as_place(current, *expr, true)? else {
                     return Ok(None);
                 };


### PR DESCRIPTION
This fixes an infinite recursion when `->` is used with a recursive data type (see #46)



<small>By submitting this pull request, I confirm that my contribution is made under the terms of the [MIT](https://github.com/verus-lang/verus-analyzer/blob/main/LICENSE-MIT) and [Apache](https://github.com/verus-lang/verus-analyzer/blob/main/LICENSE-APACHE) licenses.</small>
