### PR TITLE
Clean up Verus syntax tests

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -129,9 +129,10 @@ Failed to lift function Name(Text("ptr_null_mut")): got error: Err("type_bound_l
 ```
 This means our auto-generated lifting code failed to convert the CST provided by
 the parser into a VST representation.  To start debugging such an issue, try
-searching through `crates/syntax/src/ast/generated/vst_nodes.rs` for the term
-`stringify!(PROBLEM)`, where PROBLEM is the type name in the `Err("PROBLEM")` above.
-That may help locate the problematic code.
+searching through `crates/syntax/src/ast/generated/vst_nodes.rs` and
+`crates/syntax/src/ast/vst.rs` for the term `stringify!(PROBLEM)`, where
+PROBLEM is the type name in the `Err("PROBLEM")` above.  That may help locate
+the problematic code.
 
 ## Building a VSIX file
 

--- a/crates/parser/src/grammar/expressions.rs
+++ b/crates/parser/src/grammar/expressions.rs
@@ -400,7 +400,13 @@ const LHS_FIRST: TokenSet =
 
 fn lhs(p: &mut Parser<'_>, r: Restrictions) -> Option<(CompletedMarker, BlockLike)> {
     let m;
-    let kind = match p.current() {
+    let kind =
+    if p.at(T![|||]) || p.at(T![&&&]) {
+        m = p.start();
+        p.bump_any();
+        PREFIX_EXPR
+    } else {
+        match p.current() {
         // test ref_expr
         // fn foo() {
         //     // reference operator
@@ -467,7 +473,7 @@ fn lhs(p: &mut Parser<'_>, r: Restrictions) -> Option<(CompletedMarker, BlockLik
                 postfix_expr(p, lhs, blocklike, !(r.prefer_stmt && blocklike.is_block()));
             return Some((cm, block_like));
         }
-    };
+    }};
     // parse the interior of the unary expression
     expr_bp(p, None, r, 255);
     let cm = m.complete(p, kind);

--- a/crates/parser/src/grammar/verus.rs
+++ b/crates/parser/src/grammar/verus.rs
@@ -137,7 +137,10 @@ pub(crate) fn fn_mode(p: &mut Parser<'_>) -> CompletedMarker {
 }
 
 pub(crate) fn broadcast_group(p: &mut Parser<'_>, m: Marker) -> CompletedMarker {
+    let group_name_m = p.start();
     p.expect(IDENT); // group name
+    group_name_m.complete(p, BROADCAST_GROUP_IDENTIFIER);
+    let group_list_m = p.start();
     p.expect(T!['{']);
     while !p.at(EOF) && !p.at(T!['}']) {
         attributes::inner_attrs(p);
@@ -151,6 +154,7 @@ pub(crate) fn broadcast_group(p: &mut Parser<'_>, m: Marker) -> CompletedMarker 
         }
     }
     p.expect(T!['}']);
+    group_list_m.complete(p, BROADCAST_GROUP_LIST);
     m.complete(p, BROADCAST_GROUP)
 }
 

--- a/crates/syntax/rust.ungram
+++ b/crates/syntax/rust.ungram
@@ -446,7 +446,7 @@ BlockExpr =
 
 // verus: &&&, |||
 PrefixExpr =
-  Attr* op:('-' | '!' | '*') Expr
+  Attr* op:('-' | '!' | '*' | '&&&' | '|||') Expr
 
 // verus: ==>, !==
 BinExpr =

--- a/crates/syntax/src/lib.rs
+++ b/crates/syntax/src/lib.rs
@@ -514,10 +514,25 @@ fn api_walkthrough() {
 // Verus tests
 // Do "cargo test --package syntax --lib -- tests"
 
-#[test]
-fn verus_walkthrough0() {
+fn verus_core(source_code: &str) {
     use ast::HasModuleItem;
 
+    let parse = SourceFile::parse(source_code, Edition::Edition2024);
+    dbg!(&parse.errors);
+    assert!(parse.errors().is_empty());
+    let file: SourceFile = parse.tree();
+    //dbg!(&file);
+    for item in file.items() {
+        //dbg!(&item);
+        let v_item: vst_nodes::Item = item.try_into().unwrap();
+        //dbg!(v_item);
+    }
+}
+
+
+
+#[test]
+fn verus_walkthrough0() {
     let source_code = "verus!{
         proof fn my_proof_fun(x: int, y: int)
             {
@@ -538,23 +553,11 @@ fn verus_walkthrough0() {
             ensures(b);
         }
     }";
-    let parse = SourceFile::parse(source_code, Edition::Edition2024);
-    dbg!(&parse.errors);
-    assert!(parse.errors().is_empty());
-    let file: SourceFile = parse.tree();
-
-    dbg!(&file);
-    for item in file.items() {
-        dbg!(&item);
-        let v_item: vst_nodes::Item = item.try_into().unwrap();
-        dbg!(v_item);
-    }
+    verus_core(source_code);
 }
 
 #[test]
 fn verus_walkthrough1() {
-    use ast::HasModuleItem;
-
     let source_code = "verus!{
         proof fn my_proof_fun(x: int, y: int)
             requires
@@ -569,23 +572,11 @@ fn verus_walkthrough1() {
             assert(a & 0 == 0) by (bit_vector)
         }
     }";
-    let parse = SourceFile::parse(source_code, Edition::Edition2024);
-    dbg!(&parse.errors);
-    assert!(parse.errors().is_empty());
-    let file: SourceFile = parse.tree();
-
-    dbg!(&file);
-    for item in file.items() {
-        dbg!(&item);
-        let v_item: vst_nodes::Item = item.try_into().unwrap();
-        dbg!(v_item);
-    }
+    verus_core(source_code);
 }
 
 #[test]
 fn verus_walkthrough1_1() {
-    use ast::HasModuleItem;
-
     let source_code = "
 verus! {
     spec fn identity(x: u32) -> u32 {
@@ -603,28 +594,11 @@ verus! {
     }
 }
 ";
-
-    let parse = SourceFile::parse(source_code, Edition::Edition2024);
-    dbg!(&parse.errors);
-    assert!(parse.errors().is_empty());
-    let file: SourceFile = parse.tree();
-
-    dbg!(&file);
-    for item in file.items() {
-        dbg!(&item);
-        // match item {
-        //     ast::Item::Fn(f) => func = Some(f),
-        //     _ => unreachable!(),
-        // }
-        let v_item: vst_nodes::Item = item.try_into().unwrap();
-        dbg!(v_item);
-    }
+    verus_core(source_code);
 }
 
 #[test]
 fn verus_walkthrough2() {
-    use ast::HasModuleItem;
-
     let source_code = "verus!{
         proof fn my_proof_fun(x: int, y: int) -> (sum: int)
             requires
@@ -655,22 +629,11 @@ fn verus_walkthrough2() {
             x / 2 + y / 2
         }
     }";
-
-    let parse = SourceFile::parse(source_code, Edition::Edition2024);
-    dbg!(&parse.errors);
-    assert!(parse.errors().is_empty());
-    let file: SourceFile = parse.tree();
-    // dbg!(&file);
-    for item in file.items() {
-        dbg!(&item);
-        let v_item: vst_nodes::Item = item.try_into().unwrap();
-        dbg!(v_item);
-    }
+    verus_core(source_code);
 }
 
 #[test]
 fn verus_walkthrough3() {
-    use ast::HasModuleItem;
     let source_code = "verus!{
         proof fn test5_bound_checking(x: u32, y: u32, z: u32)
             requires
@@ -704,20 +667,11 @@ fn verus_walkthrough3() {
             }
         }
     }";
-    let parse = SourceFile::parse(source_code, Edition::Edition2024);
-    dbg!(&parse.errors);
-    assert!(parse.errors().is_empty());
-    let file: SourceFile = parse.tree();
-    for item in file.items() {
-        dbg!(&item);
-        // let v_item: vst_nodes::Item = item.try_into().unwrap();
-        // dbg!(v_item);
-    }
+    verus_core(source_code);
 }
 
 #[test]
 fn verus_walkthrough4() {
-    use ast::HasModuleItem;
     let source_code = "verus!{
         fn test_assert_forall_by() {
             assert forall|x: int, y: int| f1(x) + f1(y) == x + y + 2 by {
@@ -751,21 +705,11 @@ fn verus_walkthrough4() {
             choose|x: int| f1(x)
         }
     }";
-    let parse = SourceFile::parse(source_code, Edition::Edition2024);
-    dbg!(&parse.errors);
-    assert!(parse.errors().is_empty());
-    let file: SourceFile = parse.tree();
-    // dbg!(&file);
-    for item in file.items() {
-        dbg!(&item);
-        let v_item: vst_nodes::Item = item.try_into().unwrap();
-        dbg!(v_item);
-    }
+    verus_core(source_code);
 }
 
 #[test]
 fn verus_walkthrough5() {
-    use ast::HasModuleItem;
     let source_code =
     "verus!{
         fn test_single_trigger1() {
@@ -776,21 +720,11 @@ fn verus_walkthrough5() {
             if x>0 {1} else {-1}
         }
     }";
-    let parse = SourceFile::parse(source_code, Edition::Edition2024);
-    dbg!(&parse.errors);
-    assert!(parse.errors().is_empty());
-    let file: SourceFile = parse.tree();
-    dbg!(&file);
-    for item in file.items() {
-        dbg!(&item);
-        // let v_item: vst_nodes::Item = item.try_into().unwrap();
-        // dbg!(v_item);
-    }
+    verus_core(source_code);
 }
 
 #[test]
 fn verus_walkthrough6() {
-    use ast::HasModuleItem;
     let source_code = "verus!{
         proof fn my_proof_fun(x: int, y: int) -> (sum: int)
             requires
@@ -820,21 +754,11 @@ fn verus_walkthrough6() {
                 a.valid(),
         ;
     }";
-    let parse = SourceFile::parse(source_code, Edition::Edition2024);
-    dbg!(&parse.errors);
-    assert!(parse.errors().is_empty());
-    let file: SourceFile = parse.tree();
-    dbg!(&file);
-    for item in file.items() {
-        dbg!(&item);
-        let v_item: vst_nodes::Item = item.try_into().unwrap();
-        dbg!(v_item);
-    }
+    verus_core(source_code);
 }
 
 #[test]
 fn verus_walkthrough7() {
-    use ast::HasModuleItem;
     let source_code =
     "verus!{
         fn test_single_trigger2() {
@@ -861,21 +785,11 @@ fn verus_walkthrough7() {
             ;
         }
     }";
-    let parse = SourceFile::parse(source_code, Edition::Edition2024);
-    dbg!(&parse.errors);
-    assert!(parse.errors().is_empty());
-    let file: SourceFile = parse.tree();
-    dbg!(&file);
-    for item in file.items() {
-        dbg!(&item);
-        // let v_item: vst_nodes::Item = item.try_into().unwrap();
-        // dbg!(v_item);
-    }
+    verus_core(source_code);
 }
 
 #[test]
 fn verus_walkthrough8() {
-    use ast::HasModuleItem;
     let source_code = "verus!{
     fn test_my_funs2(
         a: u32, // exec variable
@@ -892,21 +806,11 @@ fn verus_walkthrough8() {
         }
     }
     }";
-    let parse = SourceFile::parse(source_code, Edition::Edition2024);
-    dbg!(&parse.errors);
-    assert!(parse.errors().is_empty());
-    let file: SourceFile = parse.tree();
-    dbg!(&file);
-    for item in file.items() {
-        dbg!(&item);
-        let v_item: vst_nodes::Item = item.try_into().unwrap();
-        dbg!(v_item);
-    }
+    verus_core(source_code);
 }
 
 #[test]
 fn verus_walkthrough9_0() {
-    use ast::HasModuleItem;
     let source_code = "verus!{
     fn test_is_variant_1(v: Vehicle2<u64>) {
         match v {
@@ -915,21 +819,11 @@ fn verus_walkthrough9_0() {
         };
     }
     }";
-    let parse = SourceFile::parse(source_code, Edition::Edition2024);
-    dbg!(&parse.errors);
-    assert!(parse.errors().is_empty());
-    let file: SourceFile = parse.tree();
-    dbg!(&file);
-    for item in file.items() {
-        dbg!(&item);
-        let v_item: vst_nodes::Item = item.try_into().unwrap();
-        dbg!(v_item);
-    }
+    verus_core(source_code);
 }
 
 #[test]
 fn verus_walkthrough9() {
-    use ast::HasModuleItem;
     let source_code = "verus!{
     proof fn test_tracked(
         tracked w: int,
@@ -940,21 +834,11 @@ fn verus_walkthrough9() {
 
     }
     }";
-    let parse = SourceFile::parse(source_code, Edition::Edition2024);
-    dbg!(&parse.errors);
-    assert!(parse.errors().is_empty());
-    let file: SourceFile = parse.tree();
-    dbg!(&file);
-    for item in file.items() {
-        dbg!(&item);
-        let v_item: vst_nodes::Item = item.try_into().unwrap();
-        dbg!(v_item);
-    }
+    verus_core(source_code);
 }
 
 #[test]
 fn verus_walkthrough10_0() {
-    use ast::HasModuleItem;
     let source_code = "verus!{
     pub(crate) proof fn binary_ops<A>(a: A, x: int) {
         assert(2 + 2 !== 3);
@@ -964,21 +848,11 @@ fn verus_walkthrough10_0() {
     }
 
     }";
-    let parse = SourceFile::parse(source_code, Edition::Edition2024);
-    dbg!(&parse.errors);
-    assert!(parse.errors().is_empty());
-    let file: SourceFile = parse.tree();
-    dbg!(&file);
-    for item in file.items() {
-        dbg!(&item);
-        // let v_item: vst_nodes::Item = item.try_into().unwrap();
-        // dbg!(v_item);
-    }
+    verus_core(source_code);
 }
 
 #[test]
 fn verus_walkthrough10_1() {
-    use ast::HasModuleItem;
     let source_code = "verus!{
     spec fn ccc(x: int, y: int) -> bool {
         &&& if false {
@@ -990,20 +864,11 @@ fn verus_walkthrough10_1() {
         &&& true
     }
     }";
-    let parse = SourceFile::parse(source_code, Edition::Edition2024);
-    dbg!(&parse.errors);
-    assert!(parse.errors().is_empty());
-    let file: SourceFile = parse.tree();
-    for item in file.items() {
-        dbg!(&item);
-        // let v_item: vst_nodes::Item = item.try_into().unwrap();
-        // dbg!(v_item);
-    }
+    verus_core(source_code);
 }
 
 #[test]
 fn verus_walkthrough10_2() {
-    use ast::HasModuleItem;
     let source_code = "verus!{
     spec fn complex_conjuncts(x: int, y: int) -> bool {
         let b = x < y;
@@ -1019,21 +884,11 @@ fn verus_walkthrough10_2() {
     }
 
     }";
-    let parse = SourceFile::parse(source_code, Edition::Edition2024);
-    dbg!(&parse.errors);
-    assert!(parse.errors().is_empty());
-    let file: SourceFile = parse.tree();
-    dbg!(&file);
-    for item in file.items() {
-        dbg!(&item);
-        // let v_item: vst_nodes::Item = item.try_into().unwrap();
-        // dbg!(v_item);
-    }
+    verus_core(source_code);
 }
 
 #[test]
 fn verus_walkthrough10() {
-    use ast::HasModuleItem;
     let source_code = "verus!{
     fn test_views() {
         let mut v: Vec<u8> = Vec::new();
@@ -1046,21 +901,11 @@ fn verus_walkthrough10() {
         }
     }
     }";
-    let parse = SourceFile::parse(source_code, Edition::Edition2024);
-    dbg!(&parse.errors);
-    assert!(parse.errors().is_empty());
-    let file: SourceFile = parse.tree();
-    dbg!(&file);
-    for item in file.items() {
-        dbg!(&item);
-        let v_item: vst_nodes::Item = item.try_into().unwrap();
-        dbg!(v_item);
-    }
+    verus_core(source_code);
 }
 
 #[test]
 fn verus_walkthrough11() {
-    use ast::HasModuleItem;
     let source_code = "verus!{
 fn binary_search(v: &Vec<u64>, k: u64) -> (r: usize)
     requires
@@ -1090,21 +935,11 @@ fn binary_search(v: &Vec<u64>, k: u64) -> (r: usize)
     i1
 }
     }";
-    let parse = SourceFile::parse(source_code, Edition::Edition2024);
-    dbg!(&parse.errors);
-    assert!(parse.errors().is_empty());
-    let file: SourceFile = parse.tree();
-    dbg!(&file);
-    for item in file.items() {
-        dbg!(&item);
-        // let v_item: vst_nodes::Item = item.try_into().unwrap();
-        // dbg!(v_item);
-    }
+    verus_core(source_code);
 }
 
 #[test]
 fn verus_walkthrough12() {
-    use ast::HasModuleItem;
     let source_code = "verus!{
 fn pop_test(t: Vec<u64>)
 requires
@@ -1117,21 +952,11 @@ assert(uninterp_fn(x));
 assert(forall|i: int| #![auto] 0 <= i < t.len() ==> uninterp_fn(t[i]));
 }
     }";
-    let parse = SourceFile::parse(source_code, Edition::Edition2024);
-    dbg!(&parse.errors);
-    assert!(parse.errors().is_empty());
-    let file: SourceFile = parse.tree();
-    dbg!(&file);
-    for item in file.items() {
-        dbg!(&item);
-        // let v_item: vst_nodes::Item = item.try_into().unwrap();
-        // dbg!(v_item);
-    }
+    verus_core(source_code);
 }
 
 #[test]
 fn verus_walkthrough13() {
-    use ast::HasModuleItem;
     let source_code = "verus!{
     proof fn arith_sum_int_nonneg(i: nat)
         ensures
@@ -1150,21 +975,11 @@ fn verus_walkthrough13() {
     if i <= 0 { 0 } else { i + arith_sum_int(i - 1) }
 }
     }";
-    let parse = SourceFile::parse(source_code, Edition::Edition2024);
-    dbg!(&parse.errors);
-    assert!(parse.errors().is_empty());
-    let file: SourceFile = parse.tree();
-    dbg!(&file);
-    for item in file.items() {
-        dbg!(&item);
-        let v_item: vst_nodes::Item = item.try_into().unwrap();
-        dbg!(v_item);
-    }
+    verus_core(source_code);
 }
 
 #[test]
 fn verus_walkthrough14() {
-    use ast::HasModuleItem;
     let source_code = "verus!{
 fn exec_with_decreases(n: u64) -> u64
     decreases 100 - n,
@@ -1176,21 +991,11 @@ fn exec_with_decreases(n: u64) -> u64
     }
 }
     }";
-    let parse = SourceFile::parse(source_code, Edition::Edition2024);
-    dbg!(&parse.errors);
-    assert!(parse.errors().is_empty());
-    let file: SourceFile = parse.tree();
-    dbg!(&file);
-    for item in file.items() {
-        dbg!(&item);
-        let v_item: vst_nodes::Item = item.try_into().unwrap();
-        dbg!(v_item);
-    }
+    verus_core(source_code);
 }
 
 #[test]
 fn verus_walkthrough15() {
-    use ast::HasModuleItem;
     let source_code =
     "verus!{
 spec(checked) fn my_spec_fun2(x: int, y: int) -> int
@@ -1202,21 +1007,11 @@ spec(checked) fn my_spec_fun2(x: int, y: int) -> int
     my_spec_fun(x, y)
 }
     }";
-    let parse = SourceFile::parse(source_code, Edition::Edition2024);
-    dbg!(&parse.errors);
-    assert!(parse.errors().is_empty());
-    let file: SourceFile = parse.tree();
-    dbg!(&file);
-    for item in file.items() {
-        dbg!(&item);
-        let v_item: vst_nodes::Item = item.try_into().unwrap();
-        dbg!(v_item);
-    }
+    verus_core(source_code);
 }
 
 #[test]
 fn verus_walkthrough16() {
-    use ast::HasModuleItem;
     let source_code = "verus!{
 proof fn test_even_f()
     ensures
@@ -1230,21 +1025,11 @@ proof fn test_even_f()
     }
 }
     }";
-    let parse = SourceFile::parse(source_code, Edition::Edition2024);
-    dbg!(&parse.errors);
-    assert!(parse.errors().is_empty());
-    let file: SourceFile = parse.tree();
-    dbg!(&file);
-    for item in file.items() {
-        dbg!(&item);
-        // let v_item: vst_nodes::Item = item.try_into().unwrap();
-        // dbg!(v_item);
-    }
+    verus_core(source_code);
 }
 
 #[test]
 fn verus_walkthrough17() {
-    use ast::HasModuleItem;
     //from: https://github.com/verus-lang/verus/wiki/Doc%3A-Deprecated-and-recommended-syntax%2C-and-upcoming-changes
     let source_code = "verus!{
 proof fn lemma1(i: int, tracked t: S) {
@@ -1272,21 +1057,11 @@ fn g(Tracked(t): Tracked<S>) -> u32 {
     f(5, Ghost(6), Tracked(t))
 }
     }";
-    let parse = SourceFile::parse(source_code, Edition::Edition2024);
-    dbg!(&parse.errors);
-    assert!(parse.errors().is_empty());
-    let file: SourceFile = parse.tree();
-    dbg!(&file);
-    for item in file.items() {
-        dbg!(&item);
-        let v_item: vst_nodes::Item = item.try_into().unwrap();
-        dbg!(v_item);
-    }
+    verus_core(source_code);
 }
 
 #[test]
 fn verus_walkthrough18() {
-    use ast::HasModuleItem;
     //from: https://github.com/verus-lang/verus/blob/main/source/rust_verify/example/syntax.rs
     let source_code = "
 verus!{
@@ -1319,21 +1094,11 @@ proof fn dec0_decreases(a: int) {
     // proof
 }
 } // verus!";
-    let parse = SourceFile::parse(source_code, Edition::Edition2024);
-    dbg!(&parse.errors);
-    assert!(parse.errors().is_empty());
-    let file: SourceFile = parse.tree();
-    dbg!(&file);
-    for item in file.items() {
-        dbg!(&item);
-        let v_item: vst_nodes::Item = item.try_into().unwrap();
-        dbg!(v_item);
-    }
+    verus_core(source_code);
 }
 
 #[test]
 fn verus_walkthrough19() {
-    use ast::HasModuleItem;
     //from: https://github.com/verus-lang/verus/blob/main/source/rust_verify/example/syntax.rs
     let source_code = "
 verus!{
@@ -1342,21 +1107,11 @@ tracked struct TrackedAndGhost<T, G>(
     ghost G,
 );
 } // verus!";
-    let parse = SourceFile::parse(source_code, Edition::Edition2024);
-    dbg!(&parse.errors);
-    assert!(parse.errors().is_empty());
-    let file: SourceFile = parse.tree();
-    dbg!(&file);
-    for item in file.items() {
-        dbg!(&item);
-        let v_item: vst_nodes::Item = item.try_into().unwrap();
-        dbg!(v_item);
-    }
+    verus_core(source_code);
 }
 
 #[test]
 fn verus_walkthrough20() {
-    use ast::HasModuleItem;
     //from: https://github.com/verus-lang/verus/blob/main/source/rust_verify/example/syntax.rs
     let source_code = "
 verus!{
@@ -1367,21 +1122,11 @@ proof fn lemma_mul_upper_bound(x: int, x_bound: int, y: int, y_bound: int)
 {
 }
 } // verus!";
-    let parse = SourceFile::parse(source_code, Edition::Edition2024);
-    dbg!(&parse.errors);
-    assert!(parse.errors().is_empty());
-    let file: SourceFile = parse.tree();
-    dbg!(&file);
-    for item in file.items() {
-        dbg!(&item);
-        let v_item: vst_nodes::Item = item.try_into().unwrap();
-        dbg!(v_item);
-    }
+    verus_core(source_code);
 }
 
 #[test]
 fn verus_walkthrough21() {
-    use ast::HasModuleItem;
     //from: https://github.com/verus-lang/verus/blob/main/source/rust_verify/example/syntax.rs
     let source_code = "
 verus!{
@@ -1398,21 +1143,11 @@ proof fn add0_recommends(a: nat, b: nat) {
 }
 
 } // verus!";
-    let parse = SourceFile::parse(source_code, Edition::Edition2024);
-    dbg!(&parse.errors);
-    assert!(parse.errors().is_empty());
-    let file: SourceFile = parse.tree();
-    dbg!(&file);
-    for item in file.items() {
-        dbg!(&item);
-        let v_item: vst_nodes::Item = item.try_into().unwrap();
-        dbg!(v_item);
-    }
+    verus_core(source_code);
 }
 
 #[test]
 fn verus_walkthrough22() {
-    use ast::HasModuleItem;
     //from: https://github.com/verus-lang/verus/blob/main/source/rust_verify/example/syntax.rs
     let source_code = "
 verus!{
@@ -1445,16 +1180,7 @@ proof fn dec0_decreases(a: int) {
     // proof
 }
 } // verus!";
-    let parse = SourceFile::parse(source_code, Edition::Edition2024);
-    dbg!(&parse.errors);
-    assert!(parse.errors().is_empty());
-    let file: SourceFile = parse.tree();
-    dbg!(&file);
-    for item in file.items() {
-        dbg!(&item);
-        let v_item: vst_nodes::Item = item.try_into().unwrap();
-        dbg!(v_item);
-    }
+    verus_core(source_code);
 }
 
 // verus trigger attribute is custom syntax
@@ -1470,7 +1196,6 @@ proof fn dec0_decreases(a: int) {
 // therefore, we just special-case `#[trigger]`
 #[test]
 fn verus_walkthrough23() {
-    use ast::HasModuleItem;
     //from: https://github.com/verus-lang/verus/blob/main/source/rust_verify/example/syntax.rs
     let source_code = "
 verus!{
@@ -1482,21 +1207,11 @@ verus!{
         );
     }
 } // verus!";
-    let parse = SourceFile::parse(source_code, Edition::Edition2024);
-    dbg!(&parse.errors);
-    assert!(parse.errors().is_empty());
-    let file: SourceFile = parse.tree();
-    dbg!(&file);
-    for item in file.items() {
-        dbg!(&item);
-        // let v_item: vst_nodes::Item = item.try_into().unwrap();
-        // dbg!(v_item);
-    }
+    verus_core(source_code);
 }
 
 #[test]
 fn verus_walkthrough24() {
-    use ast::HasModuleItem;
     //from: https://github.com/verus-lang/verus/blob/main/source/rust_verify/example/syntax.rs
     let source_code = "
 verus!{
@@ -1512,21 +1227,11 @@ spec fn test_rec2(x: int, y: int) -> int
     }
 }
 } // verus!";
-    let parse = SourceFile::parse(source_code, Edition::Edition2024);
-    dbg!(&parse.errors);
-    assert!(parse.errors().is_empty());
-    let file: SourceFile = parse.tree();
-    dbg!(&file);
-    for item in file.items() {
-        dbg!(&item);
-        let v_item: vst_nodes::Item = item.try_into().unwrap();
-        dbg!(v_item);
-    }
+    verus_core(source_code);
 }
 
 #[test]
 fn verus_walkthrough25() {
-    use ast::HasModuleItem;
     // https://github.com/verus-lang/verus/blob/ed95a417a236707fbb50efd96c91cb217ed2b22a/source/rust_verify/example/vectors.rs
     let source_code = "
 verus!{
@@ -1548,43 +1253,22 @@ verus!{
         v
     }
 } // verus!";
-    let parse = SourceFile::parse(source_code, Edition::Edition2024);
-    dbg!(&parse.errors);
-    assert!(parse.errors().is_empty());
-    let file: SourceFile = parse.tree();
-    dbg!(&file);
-    for item in file.items() {
-        dbg!(&item);
-        // let v_item: vst_nodes::Item = item.try_into().unwrap();
-        // dbg!(&v_item);
-        // println!("{}", &v_item);
-    }
+    verus_core(source_code);
 }
 
 #[test]
 fn verus_anonymous_return_types() {
-    use ast::HasModuleItem;
     let source_code = "verus!{
 fn foo() -> (u32, u32)
 {
     (1, 2)
 }
     }";
-    let parse = SourceFile::parse(source_code, Edition::Edition2024);
-    dbg!(&parse.errors);
-    assert!(parse.errors().is_empty());
-    let file: SourceFile = parse.tree();
-    dbg!(&file);
-    for item in file.items() {
-        dbg!(&item);
-        // let v_item: vst_nodes::Item = item.try_into().unwrap();
-        // dbg!(v_item);
-    }
+    verus_core(source_code);
 }
 
 #[test]
 fn verus_struct_syntax() {
-    use ast::HasModuleItem;
     let source_code = "verus!{
 proof fn sufficiently_creamy() -> bool
     requires 
@@ -1622,21 +1306,11 @@ spec fn walks_upright(l: Life) -> bool
     l matches Life::Mammal{legs, ..} ==> legs==2
 }
     }";
-    let parse = SourceFile::parse(source_code, Edition::Edition2024);
-    dbg!(&parse.errors);
-    assert!(parse.errors().is_empty());
-    let file: SourceFile = parse.tree();
-    dbg!(&file);
-    for item in file.items() {
-        dbg!(&item);
-        // let v_item: vst_nodes::Item = item.try_into().unwrap();
-        // dbg!(v_item);
-    }
+    verus_core(source_code);
 }
 
 #[test]
 fn verus_has() {
-    use ast::HasModuleItem;
     let source_code = "verus!{
 fn uses_spec_has()
     requires
@@ -1657,21 +1331,11 @@ fn uses_spec_has()
     assert(ms !has 4 == ms !has 4);
 }
     }";
-    let parse = SourceFile::parse(source_code, Edition::Edition2024);
-    dbg!(&parse.errors);
-    assert!(parse.errors().is_empty());
-    let file: SourceFile = parse.tree();
-    dbg!(&file);
-    for item in file.items() {
-        dbg!(&item);
-        // let v_item: vst_nodes::Item = item.try_into().unwrap();
-        // dbg!(v_item);
-    }
+    verus_core(source_code);
 }
 
 #[test]
 fn verus_while_loops() {
-    use ast::HasModuleItem;
     let source_code = "verus!{
 pub fn clone_vec_u8() {
     let i = 0;
@@ -1691,21 +1355,11 @@ pub fn clone_vec_u8() {
     }
 }
     }";
-    let parse = SourceFile::parse(source_code, Edition::Edition2024);
-    dbg!(&parse.errors);
-    assert!(parse.errors().is_empty());
-    let file: SourceFile = parse.tree();
-    dbg!(&file);
-    for item in file.items() {
-        dbg!(&item);
-        // let v_item: vst_nodes::Item = item.try_into().unwrap();
-        // dbg!(v_item);
-    }
+    verus_core(source_code);
 }
 
 #[test]
 fn verus_loops() {
-    use ast::HasModuleItem;
     let source_code = "verus!{
 fn test() {
     loop
@@ -1727,21 +1381,11 @@ fn test() {
     }
 }
     }";
-    let parse = SourceFile::parse(source_code, Edition::Edition2024);
-    dbg!(&parse.errors);
-    assert!(parse.errors().is_empty());
-    let file: SourceFile = parse.tree();
-    dbg!(&file);
-    for item in file.items() {
-        dbg!(&item);
-        // let v_item: vst_nodes::Item = item.try_into().unwrap();
-        // dbg!(v_item);
-    }
+    verus_core(source_code);
 }
 
 #[test]
 fn verus_for_loops() {
-    use ast::HasModuleItem;
     let source_code = "verus!{
 fn reverse(v: &mut Vec<u64>)
     ensures
@@ -1793,21 +1437,11 @@ fn test() {
     }
 }
     }";
-    let parse = SourceFile::parse(source_code, Edition::Edition2024);
-    dbg!(&parse.errors);
-    assert!(parse.errors().is_empty());
-    let file: SourceFile = parse.tree();
-    dbg!(&file);
-    for item in file.items() {
-        dbg!(&item);
-        // let v_item: vst_nodes::Item = item.try_into().unwrap();
-        // dbg!(v_item);
-    }
+    verus_core(source_code);
 }
 
 #[test]
 fn verus_broadcast() {
-    use ast::HasModuleItem;
     let source_code = "verus!{
 mod ring {
     use builtin::*;
@@ -1882,37 +1516,19 @@ mod m4 {
 }
 }";
 
-    let parse = SourceFile::parse(source_code, Edition::Edition2024);
-    dbg!(&parse.errors);
-    assert!(parse.errors().is_empty());
-    let file: SourceFile = parse.tree();
-    dbg!(&file);
-    for item in file.items() {
-        dbg!(&item);
-        // let v_item: vst_nodes::Item = item.try_into().unwrap();
-        // dbg!(v_item);
-    }
+    verus_core(source_code);
 }
 
 #[test]
 fn verus_broadcast_regression() {
-    use ast::HasModuleItem;
     let source_code = "verus!{
 fn f() { let group = Group::new(Delimiter::Bracket, bracketed.build()); let mut group = crate::Group::_new_fallback(group); group.set_span(span); trees.push_token_from_parser(TokenTree::Group(group)); }
 }";
-    let parse = SourceFile::parse(source_code, Edition::Edition2024);
-    dbg!(&parse.errors);
-    assert!(parse.errors().is_empty());
-    let file: SourceFile = parse.tree();
-    dbg!(&file);
-    for item in file.items() {
-        dbg!(&item);
-    }
+    verus_core(source_code);
 }
 
 #[test]
 fn verus_where_clauses() {
-    use ast::HasModuleItem;
     let source_code = "verus!{
 pub fn spawn<F, Ret>(f: F) -> (handle: JoinHandle<Ret>) where
     F: FnOnce() -> Ret,
@@ -1934,21 +1550,11 @@ pub fn write(in_v: V) where V: Copy
 }
 }";
 
-    let parse = SourceFile::parse(source_code, Edition::Edition2024);
-    dbg!(&parse.errors);
-    assert!(parse.errors().is_empty());
-    let file: SourceFile = parse.tree();
-    dbg!(&file);
-    for item in file.items() {
-        dbg!(&item);
-        // let v_item: vst_nodes::Item = item.try_into().unwrap();
-        // dbg!(v_item);
-    }
+    verus_core(source_code);
 }
 
 #[test]
 fn verus_opens_invariants() {
-    use ast::HasModuleItem;
     let source_code = "verus!{
 fn inv1()
     opens_invariants none
@@ -1994,21 +1600,11 @@ fn kw_test() {
 }
 
 }";
-    let parse = SourceFile::parse(source_code, Edition::Edition2024);
-    dbg!(&parse.errors);
-    assert!(parse.errors().is_empty());
-    let file: SourceFile = parse.tree();
-    dbg!(&file);
-    for item in file.items() {
-        dbg!(&item);
-        // let v_item: vst_nodes::Item = item.try_into().unwrap();
-        // dbg!(v_item);
-    }
+    verus_core(source_code);
 }
 
 #[test]
 fn verus_tracked() {
-    use ast::HasModuleItem;
     let source_code = "verus!{
 fn is_nonnull(tracked &self)
 {
@@ -2018,22 +1614,11 @@ fn into_raw() -> (tracked points_to_raw: PointsToRaw)
 {
 }
 }";
-
-    let parse = SourceFile::parse(source_code, Edition::Edition2024);
-    dbg!(&parse.errors);
-    assert!(parse.errors().is_empty());
-    let file: SourceFile = parse.tree();
-    dbg!(&file);
-    for item in file.items() {
-        dbg!(&item);
-        // let v_item: vst_nodes::Item = item.try_into().unwrap();
-        // dbg!(v_item);
-    }
+    verus_core(source_code);
 }
 
 #[test]
 fn verus_higher_order_functions() {
-    use ast::HasModuleItem;
     let source_code = "verus!{
 pub fn spawn(f: F) 
     requires
@@ -2044,21 +1629,11 @@ pub fn spawn(f: F)
 }
 }";
 
-    let parse = SourceFile::parse(source_code, Edition::Edition2024);
-    dbg!(&parse.errors);
-    assert!(parse.errors().is_empty());
-    let file: SourceFile = parse.tree();
-    dbg!(&file);
-    for item in file.items() {
-        dbg!(&item);
-        // let v_item: vst_nodes::Item = item.try_into().unwrap();
-        // dbg!(v_item);
-    }
+    verus_core(source_code);
 }
 
 #[test]
 fn verus_triggers() {
-    use ast::HasModuleItem;
     let source_code = "verus!{
 fn lemma()
     ensures
@@ -2078,21 +1653,11 @@ fn lemma_mul_by_zero_is_zero()
 }
 }";
 
-    let parse = SourceFile::parse(source_code, Edition::Edition2024);
-    dbg!(&parse.errors);
-    assert!(parse.errors().is_empty());
-    let file: SourceFile = parse.tree();
-    dbg!(&file);
-    for item in file.items() {
-        dbg!(&item);
-        // let v_item: vst_nodes::Item = item.try_into().unwrap();
-        // dbg!(v_item);
-    }
+    verus_core(source_code);
 }
 
 #[test]
 fn verus_triple_ops() {
-    use ast::HasModuleItem;
     let source_code = "verus!{
 spec fn test(a: bool, b:bool) -> bool {
     ||| {
@@ -2119,21 +1684,11 @@ proof fn testp(a: bool, b:bool)
 }
 }";
 
-    let parse = SourceFile::parse(source_code, Edition::Edition2024);
-    dbg!(&parse.errors);
-    assert!(parse.errors().is_empty());
-    let file: SourceFile = parse.tree();
-    dbg!(&file);
-    for item in file.items() {
-        dbg!(&item);
-        // let v_item: vst_nodes::Item = item.try_into().unwrap();
-        // dbg!(v_item);
-    }
+    verus_core(source_code);
 }
 
 #[test]
 fn verus_assume_specification() {
-    use ast::HasModuleItem;
     let source_code = "verus!{
 pub assume_specification<T> [core::mem::swap::<T>] (a: &mut T, b: &mut T)
     ensures
@@ -2154,21 +1709,11 @@ pub assume_specification [<bool as Clone>::clone](b: &bool) -> (res: bool)
     ensures res == b;
 }";
 
-    let parse = SourceFile::parse(source_code, Edition::Edition2024);
-    dbg!(&parse.errors);
-    assert!(parse.errors().is_empty());
-    let file: SourceFile = parse.tree();
-    dbg!(&file);
-    for item in file.items() {
-        dbg!(&item);
-        // let v_item: vst_nodes::Item = item.try_into().unwrap();
-        // dbg!(v_item);
-    }
+    verus_core(source_code);
 }
 
 #[test]
 fn verus_returns() {
-    use ast::HasModuleItem;
     let source_code = "verus!{
 fn test() -> u8
     returns 20u8,
@@ -2247,22 +1792,12 @@ pub assume_specification<T, I>[ <[T]>::get::<I> ](slice: &[T], i: I) -> (b: Opti
 
 }";
 
-    let parse = SourceFile::parse(source_code, Edition::Edition2024);
-    dbg!(&parse.errors);
-    assert!(parse.errors().is_empty());
-    let file: SourceFile = parse.tree();
-    dbg!(&file);
-    for item in file.items() {
-        dbg!(&item);
-        // let v_item: vst_nodes::Item = item.try_into().unwrap();
-        // dbg!(v_item);
-    }
+    verus_core(source_code);
 }
 
 
 #[test]
 fn verus_globals() {
-    use ast::HasModuleItem;
     let source_code = "verus!{
 global size_of usize == 4;
 
@@ -2279,21 +1814,11 @@ global layout S<u64> is size == 16, align == 8;
 global layout S<u32> is size == 8, align == 4;
 }";
 
-    let parse = SourceFile::parse(source_code, Edition::Edition2024);
-    dbg!(&parse.errors);
-    assert!(parse.errors().is_empty());
-    let file: SourceFile = parse.tree();
-    dbg!(&file);
-    for item in file.items() {
-        dbg!(&item);
-        // let v_item: vst_nodes::Item = item.try_into().unwrap();
-        // dbg!(v_item);
-    }
+    verus_core(source_code);
 }
 
 #[test]
 fn verus_normal_rust() {
-    use ast::HasModuleItem;
     let source_code = "
 fn check(attrs: Vec<u64>) {
     assert!(1 > 0);
@@ -2303,60 +1828,30 @@ fn check(attrs: Vec<u64>) {
 }
 ";
 
-    let parse = SourceFile::parse(source_code, Edition::Edition2024);
-    dbg!(&parse.errors);
-    assert!(parse.errors().is_empty());
-    let file: SourceFile = parse.tree();
-    dbg!(&file);
-    for item in file.items() {
-        dbg!(&item);
-        // let v_item: vst_nodes::Item = item.try_into().unwrap();
-        // dbg!(v_item);
-    }
+    verus_core(source_code);
 }
 
 #[test]
 fn verus_axioms() {
-    use ast::HasModuleItem;
     let source_code = "verus!{
 pub axiom fn foo(x: u8) requires x == 5; 
 }";
 
-    let parse = SourceFile::parse(source_code, Edition::Edition2024);
-    dbg!(&parse.errors);
-    assert!(parse.errors().is_empty());
-    let file: SourceFile = parse.tree();
-    dbg!(&file);
-    for item in file.items() {
-        dbg!(&item);
-        // let v_item: vst_nodes::Item = item.try_into().unwrap();
-        // dbg!(v_item);
-    }
+    verus_core(source_code);
 }
 
 #[test]
 fn verus_uninterp() {
-    use ast::HasModuleItem;
     let source_code = "verus!{
 pub uninterp spec fn bar() -> bool;
 }";
 
-    let parse = SourceFile::parse(source_code, Edition::Edition2024);
-    dbg!(&parse.errors);
-    assert!(parse.errors().is_empty());
-    let file: SourceFile = parse.tree();
-    dbg!(&file);
-    for item in file.items() {
-        dbg!(&item);
-        // let v_item: vst_nodes::Item = item.try_into().unwrap();
-        // dbg!(v_item);
-    }
+    verus_core(source_code);
 }
 
 
 #[test]
 fn verus_fn_signatures() {
-    use ast::HasModuleItem;
     let source_code = "verus!{
 trait T { }
 
@@ -2370,21 +1865,11 @@ spec fn v<K>()
 }
 }";
 
-    let parse = SourceFile::parse(source_code, Edition::Edition2024);
-    dbg!(&parse.errors);
-    assert!(parse.errors().is_empty());
-    let file: SourceFile = parse.tree();
-    dbg!(&file);
-    for item in file.items() {
-        dbg!(&item);
-        // let v_item: vst_nodes::Item = item.try_into().unwrap();
-        // dbg!(v_item);
-    }
+    verus_core(source_code);
 }
 
 #[test]
 fn cst_to_vst1() {
-    use ast::HasModuleItem;
     let source_code = "
 verus!{
 spec fn sum(x: int, y: int) -> int
@@ -2392,22 +1877,11 @@ spec fn sum(x: int, y: int) -> int
     x + y
 }
 } // verus!";
-    let parse = SourceFile::parse(source_code, Edition::Edition2024);
-    dbg!(&parse.errors);
-    assert!(parse.errors().is_empty());
-    let file: SourceFile = parse.tree();
-    dbg!(&file);
-    for item in file.items() {
-        dbg!(&item);
-        let v_item: vst_nodes::Item = item.try_into().unwrap();
-        dbg!(&v_item);
-        println!("{}", &v_item);
-    }
+    verus_core(source_code);
 }
 
 #[test]
 fn cst_to_vst2() {
-    use ast::HasModuleItem;
     let source_code = "
 verus!{
 spec fn test_rec2(x: int, y: int) -> int
@@ -2420,17 +1894,7 @@ spec fn test_rec2(x: int, y: int) -> int
     }
 }
 } // verus!";
-    let parse = SourceFile::parse(source_code, Edition::Edition2024);
-    dbg!(&parse.errors);
-    assert!(parse.errors().is_empty());
-    let file: SourceFile = parse.tree();
-    dbg!(&file);
-    for item in file.items() {
-        dbg!(&item);
-        let v_item: vst_nodes::Item = item.try_into().unwrap();
-        dbg!(&v_item);
-        println!("{}", &v_item);
-    }
+    verus_core(source_code);
 }
 
 /*

--- a/crates/syntax/src/lib.rs
+++ b/crates/syntax/src/lib.rs
@@ -68,7 +68,6 @@ pub use rowan::{
 pub use rustc_lexer::unescape;
 pub use smol_str::{format_smolstr, SmolStr};
 
-#[cfg(test)]
 use ast::generated::vst_nodes;
 
 /// `Parse` is the result of the parsing: a syntax tree and a collection of
@@ -524,7 +523,7 @@ fn verus_core(source_code: &str) {
     //dbg!(&file);
     for item in file.items() {
         //dbg!(&item);
-        let v_item: vst_nodes::Item = item.try_into().unwrap();
+        let _v_item: vst_nodes::Item = item.try_into().unwrap();
         //dbg!(v_item);
     }
 }

--- a/crates/va-test/examples/misc-parsing/src/main.rs
+++ b/crates/va-test/examples/misc-parsing/src/main.rs
@@ -2,29 +2,77 @@ use vstd::prelude::*;
 
 verus! {
 
-//spec fn test(a: bool, b:bool) -> bool {
-//    ||| {
-//        a
-//    }
-//    ||| b
-//}
-proof fn tester()
-    requires
-        ({ 
-            let x = a;
-            &&& a
-        }),
-{
+mod ring {
+    use builtin::*;
+
+    pub struct Ring {
+        pub i: u64,
+    }
+
+    impl Ring {
+        pub closed spec fn inv(&self) -> bool {
+            self.i < 10
+        }
+
+        pub closed spec fn spec_succ(&self) -> Ring {
+            Ring { i: if self.i == 9 { 0 } else { (self.i + 1) as u64 } }
+        }
+
+        pub closed spec fn spec_prev(&self) -> Ring {
+            Ring { i: if self.i == 0 { 9 } else { (self.i - 1) as u64 } }
+        }
+
+        pub broadcast proof fn spec_succ_ensures(p: Ring)
+            requires p.inv()
+            ensures p.inv() && (#[trigger] p.spec_succ()).spec_prev() == p
+        { }
+
+        pub broadcast proof fn spec_prev_ensures(p: Ring)
+            requires p.inv()
+            ensures p.inv() && (#[trigger] p.spec_prev()).spec_succ() == p
+        { }
+
+        pub    broadcast    group    properties {
+        Ring::spec_succ_ensures,
+                Ring::spec_prev_ensures,
+        }
+    }
+
+    #[verifier::prune_unless_this_module_is_used]
+    pub    broadcast    group    properties {
+    Ring::spec_succ_ensures,
+            Ring::spec_prev_ensures,
+    }
 }
-//proof fn testp(a: bool, b:bool) 
-//    requires 
-//        ({
-//            ||| { a }
-//            ||| b
-//        }),
-//    ensures true,
-//{
-//}
+
+mod m2 {
+    use builtin::*;
+    use crate::ring::*;
+
+    fn t2(p: Ring) requires p.inv() {
+           broadcast    use     Ring::properties;
+        assert(p.spec_succ().spec_prev() == p);
+        assert(p.spec_prev().spec_succ() == p);
+    }
+}
+
+mod m3 {
+    use builtin::*;
+    use crate::ring::*;
+
+        broadcast   use    Ring::properties;
+        
+        fn a() { }
+}
+
+mod m4 {
+    use builtin::*;
+    use crate::ring::*;
+
+        broadcast   use    
+                    Ring::spec_succ_ensures,
+            Ring::spec_prev_ensures;
+}
 
 } // verus!
 

--- a/crates/va-test/examples/misc-parsing/src/main.rs
+++ b/crates/va-test/examples/misc-parsing/src/main.rs
@@ -2,10 +2,29 @@ use vstd::prelude::*;
 
 verus! {
 
-pub open (crate) spec fn test1() {}
-pub open (in foo) spec fn test2() {}
-pub open (in crate::m) spec fn test3() { }
-pub open (super) spec fn test4() {}
+//spec fn test(a: bool, b:bool) -> bool {
+//    ||| {
+//        a
+//    }
+//    ||| b
+//}
+proof fn tester()
+    requires
+        ({ 
+            let x = a;
+            &&& a
+        }),
+{
+}
+//proof fn testp(a: bool, b:bool) 
+//    requires 
+//        ({
+//            ||| { a }
+//            ||| b
+//        }),
+//    ensures true,
+//{
+//}
 
 } // verus!
 


### PR DESCRIPTION
Factor out redundant code in the tests.  This revealed two problematic tests that didn't successfully lift to VST.  These have both been repaired.

<small>By submitting this pull request, I confirm that my contribution is made under the terms of the [MIT](https://github.com/verus-lang/verus-analyzer/blob/main/LICENSE-MIT) and [Apache](https://github.com/verus-lang/verus-analyzer/blob/main/LICENSE-APACHE) licenses.</small>
