### PR TITLE
Update verusfmt version

### DIFF
--- a/crates/ide-assists/Cargo.toml
+++ b/crates/ide-assists/Cargo.toml
@@ -26,8 +26,8 @@ text-edit.workspace = true
 ide-db.workspace = true
 hir.workspace = true
 
-# verusfmt = { version = "0.4.0", default-features = false }
-verusfmt = { git = "https://github.com/verus-lang/verusfmt.git", branch = "optional-updater", default-features = false }
+# verusfmt = { git = "https://github.com/verus-lang/verusfmt.git", branch = "optional-updater", default-features = false }
+verusfmt = { version = "0.5.5", default-features = false }
 tempfile = "3.10.1"
 
 #[dev-dependencies]


### PR DESCRIPTION
Fix the compile error when add `ide-assists`as a package.

When add `ide-assists`as a package in a project, such as
```
[package]
name = "va_test"
version = "0.1.0"
edition = "2024"

[dependencies]
ide-assists = { path = "../verus-analyzer/crates/ide-assists" }
```

The compilation fails and the error message is:
```
$ cargo build      
    Updating crates.io index
    Updating git repository `https://github.com/verus-lang/verusfmt.git`
error: failed to get `verusfmt` as a dependency of package `ide-assists v0.0.0 (/home/yuwei/ruzykaller/verus-analyzer/crates/ide-assists)`
    ... which satisfies path dependency `ide-assists` of package `va_test v0.1.0 (/home/yuwei/ruzykaller/va_test)`

Caused by:
  failed to load source for dependency `verusfmt`

Caused by:
  Unable to update https://github.com/verus-lang/verusfmt.git?branch=optional-updater

Caused by:
  failed to find branch `optional-updater`

Caused by:
  cannot locate remote-tracking branch 'origin/optional-updater'; class=Reference (4); code=NotFound (-3)
```

Note: this error won't happen when compile `ide-assists`, only happens when add it as a package, which is weird.

<small>By submitting this pull request, I confirm that my contribution is made under the terms of the [MIT](https://github.com/verus-lang/verus-analyzer/blob/main/LICENSE-MIT) and [Apache](https://github.com/verus-lang/verus-analyzer/blob/main/LICENSE-APACHE) licenses.</small>
