### PR TITLE
Fix the `is_none_or` compile error in `hir-ty` under new Rust compilers

### DIFF
--- a/crates/hir-ty/src/display.rs
+++ b/crates/hir-ty/src/display.rs
@@ -1429,12 +1429,14 @@ fn generic_args_sans_defaults<'ga>(
                     }
                     // otherwise, if the arg is equal to the param default, hide it (unless the
                     // default is an error which can happen for the trait Self type)
-                    #[allow(unstable_name_collisions)]
-                    default_parameters.get(i).is_none_or(|default_parameter| {
-                        // !is_err(default_parameter.skip_binders())
-                        //     &&
-                        arg != &default_parameter.clone().substitute(Interner, &parameters)
-                    })
+                    match default_parameters.get(i) {
+                        None => true,
+                        Some(default_parameter) => {
+                            // !is_err(default_parameter.skip_binders())
+                            //     &&
+                            arg != &default_parameter.clone().substitute(Interner, &parameters)
+                        }
+                    }
                 };
                 let mut default_from = 0;
                 for (i, parameter) in parameters.iter().enumerate() {


### PR DESCRIPTION

<small>By submitting this pull request, I confirm that my contribution is made under the terms of the [MIT](https://github.com/verus-lang/verus-analyzer/blob/main/LICENSE-MIT) and [Apache](https://github.com/verus-lang/verus-analyzer/blob/main/LICENSE-APACHE) licenses.</small>

I am using `rustc 1.82.0 (f6e511eec 2024-10-15)` to build the analyzer, but the compiler gives the following error:

```
error[E0658]: use of unstable library feature 'is_none_or'
    --> crates/hir-ty/src/display.rs:1433:47
     |
1433 |                     default_parameters.get(i).is_none_or(|default_parameter| {
     |                                               ^^^^^^^^^^
     |
     = note: see issue #126383 <https://github.com/rust-lang/rust/issues/126383> for more information
     = help: add `#![feature(is_none_or)]` to the crate attributes to enable
     = note: this compiler was built on 2024-07-24; consider upgrading it if it is out of date

For more information about this error, try `rustc --explain E0658`.
error: could not compile `hir-ty` (lib) due to 1 previous error
```

I suppose that this is a simple error that can be resolved by manually implementing `is_none_or` using `match`. It should make the code a bit more verbose but would be compatible to more Rust versions.

After this modification, the analyzer can be built and tested on my environment.

I would appreciate your ideas on this fix.