### PR TITLE
Flycheck `mod.rs` module files

### DIFF
--- a/crates/flycheck/src/lib.rs
+++ b/crates/flycheck/src/lib.rs
@@ -634,14 +634,13 @@ impl FlycheckActor {
 
                         match root_file {
                             Some(root_file) => {
-                                let file_as_module = Some(
-                                    file.strip_prefix(toml_dir.join("src"))
-                                        .unwrap()
-                                        .to_str()
-                                        .unwrap()
-                                        .replace(std::path::MAIN_SEPARATOR_STR, "::")
-                                        .replace(".rs", ""),
-                                );
+                                let file_as_module = file
+                                    .strip_prefix(toml_dir.join("src"))
+                                    .unwrap()
+                                    .to_str()
+                                    .unwrap()
+                                    .replace(std::path::MAIN_SEPARATOR_STR, "::")
+                                    .replace(".rs", "");
 
                                 args.insert(0, root_file.to_str().unwrap().to_string());
                                 if file == root_file {
@@ -649,7 +648,13 @@ impl FlycheckActor {
                                 } else {
                                     tracing::info!(?root_file, "root_file");
                                     args.insert(1, "--verify-module".to_string());
-                                    args.insert(2, file_as_module.unwrap().to_string());
+                                    // Trimming `::mod` instead of trimming `mod` and conditionally
+                                    // checking for a `::` before it. This works because a `mod.rs`
+                                    // file at the source root can define a module called `mod`. 
+                                    args.insert(
+                                        2,
+                                        file_as_module.trim_end_matches("::mod").to_string(),
+                                    );
                                 }
                             }
                             None => {


### PR DESCRIPTION
Flychecking uses the path of the file to determine the module it defines. Therefore, a file such as `src/foo/mod.rs` would by flychecked using the module path `foo::mod`, but it should actually be flychecked with `foo`. This PR removes these extra suffixes from the arguments to the verus command.

There are exotic cases where the name of a module is actually `mod`. This can happen for the file `src/mod.rs` as well as for `src/.../mod/mod.rs`. Both cases are still allowed. 

<small>By submitting this pull request, I confirm that my contribution is made under the terms of the [MIT](https://github.com/verus-lang/verus-analyzer/blob/main/LICENSE-MIT) and [Apache](https://github.com/verus-lang/verus-analyzer/blob/main/LICENSE-APACHE) licenses.</small>
