### PR TITLE
feat: Add Fold Proof Block Command

### DIFF
--- a/crates/ide/src/folding_ranges.rs
+++ b/crates/ide/src/folding_ranges.rs
@@ -25,6 +25,7 @@ pub enum FoldKind {
     WhereClause,
     ReturnType,
     MatchArm,
+    ProofBlock,
 }
 
 #[derive(Debug)]
@@ -50,13 +51,34 @@ pub(crate) fn folding_ranges(file: &SourceFile) -> Vec<Fold> {
 
     for element in file.syntax().descendants_with_tokens() {
         // Fold items that span multiple lines
-        if let Some(kind) = fold_kind(element.kind()) {
+        if let Some(mut kind) = fold_kind(element.kind()) {
             let is_multiline = match &element {
-                NodeOrToken::Node(node) => node.text().contains_char('\n'),
+                NodeOrToken::Node(node) => {
+                    if kind == FoldKind::Block && is_proof_block(node) {
+                        kind = FoldKind::ProofBlock;
+                    }
+                    node.text().contains_char('\n')
+                }
                 NodeOrToken::Token(token) => token.text().contains('\n'),
             };
             if is_multiline {
-                res.push(Fold { range: element.text_range(), kind });
+                let range = if kind == FoldKind::ProofBlock {
+                    let l_curly = element
+                        .as_node()
+                        .and_then(|n| n.children().find(|it| it.kind() == STMT_LIST))
+                        .and_then(|stmt_list| {
+                            stmt_list.children_with_tokens().find(|it| it.kind() == L_CURLY)
+                        });
+
+                    if let Some(NodeOrToken::Token(l_curly)) = l_curly {
+                        TextRange::new(l_curly.text_range().start(), element.text_range().end())
+                    } else {
+                        element.text_range()
+                    }
+                } else {
+                    element.text_range()
+                };
+                res.push(Fold { range, kind });
                 continue;
             }
         }
@@ -258,6 +280,78 @@ fn contiguous_range_for_comment(
     }
 }
 
+fn is_proof_block(node: &syntax::SyntaxNode) -> bool {
+    match node.kind() {
+        BLOCK_EXPR => {
+            // proof { ... } — FN_MODE is a direct child of BLOCK_EXPR
+            if node.children().any(|child| {
+                child.kind() == FN_MODE
+                    && child.children_with_tokens().any(|it| it.kind() == PROOF_KW)
+            }) {
+                return true;
+            }
+            if let Some(parent) = node.parent() {
+                // proof! { ... } — parent is PREFIX_EXPR containing FN_MODE(PROOF_KW) and BANG
+                if parent.kind() == PREFIX_EXPR {
+                    let has_proof_mode = parent.children().any(|child| {
+                        child.kind() == FN_MODE
+                            && child.children_with_tokens().any(|it| it.kind() == PROOF_KW)
+                    });
+                    let has_bang = parent.children_with_tokens().any(|it| it.kind() == BANG);
+                    return has_proof_mode && has_bang;
+                }
+                // assert(...) by { ... } — parent is ASSERT_EXPR with a BY_KW sibling
+                if parent.kind() == ASSERT_EXPR {
+                    return parent
+                        .children_with_tokens()
+                        .any(|it| it.kind() == BY_KW);
+                }
+                // proof fn foo() { ... } — parent is FN with FN_MODE(PROOF_KW)
+                if parent.kind() == FN {
+                    return parent.children().any(|child| {
+                        child.kind() == FN_MODE
+                            && child.children_with_tokens().any(|it| it.kind() == PROOF_KW)
+                    });
+                }
+            }
+            false
+        }
+        TOKEN_TREE => {
+            if let Some(parent) = node.parent() {
+                // proof_decl! { ... } — parent MACRO_CALL whose path text is "proof_decl"
+                if parent.kind() == MACRO_CALL {
+                    return parent.children().any(|child| {
+                        child.kind() == PATH && child.text().to_string().trim() == "proof_decl"
+                    });
+                }
+                // ghost name => { ... } inside atomic_with_ghost!:
+                // TOKEN_TREE starting with L_CURLY whose preceding siblings in a TOKEN_TREE
+                // contain a GHOST_KW (pattern: ghost <ident> => { ... })
+                if parent.kind() == TOKEN_TREE {
+                    let starts_with_curly = node
+                        .children_with_tokens()
+                        .next()
+                        .map_or(false, |it| it.kind() == L_CURLY);
+                    if starts_with_curly {
+                        let mut found_ghost = false;
+                        let mut sib = node.prev_sibling_or_token();
+                        while let Some(s) = sib {
+                            if s.kind() == GHOST_KW {
+                                found_ghost = true;
+                                break;
+                            }
+                            sib = s.prev_sibling_or_token();
+                        }
+                        return found_ghost;
+                    }
+                }
+            }
+            false
+        }
+        _ => false,
+    }
+}
+
 fn fold_range_for_where_clause(where_clause: ast::WhereClause) -> Option<TextRange> {
     let first_where_pred = where_clause.predicates().next();
     let last_where_pred = where_clause.predicates().last();
@@ -316,9 +410,94 @@ mod tests {
                 FoldKind::WhereClause => "whereclause",
                 FoldKind::ReturnType => "returntype",
                 FoldKind::MatchArm => "matcharm",
+                FoldKind::ProofBlock => "proof_block",
             };
             assert_eq!(kind, &attr.unwrap());
         }
+    }
+
+    #[test]
+    fn fold_proof_block() {
+        check(
+            r#"
+fn main() <fold block>{
+    proof <fold proof_block>{
+        assert(true);
+    }</fold>
+}</fold>
+"#,
+        );
+    }
+
+    #[test]
+    fn fold_proof_bang_block() {
+        check(
+            r#"
+fn main() <fold block>{
+    proof! <fold proof_block>{
+        assert(true);
+    }</fold>
+}</fold>
+"#,
+        );
+    }
+
+    #[test]
+    fn fold_proof_decl_block() {
+        check(
+            r#"
+fn main() <fold block>{
+    proof_decl! <fold proof_block>{
+        let tracked mut g = 0u32;
+    }</fold>
+}</fold>
+"#,
+        );
+    }
+
+    #[test]
+    fn fold_atomic_with_ghost_block() {
+        check(
+            r#"
+fn main() <fold block>{
+    let value = AtomicBool::new(0);
+    atomic_with_ghost! <fold block>(
+        value => compare_exchange(false, true);
+        returning res;
+        ghost g => <fold proof_block>{
+            assert(true);
+        }</fold>
+    )</fold>;
+}</fold>
+"#,
+        );
+    }
+
+    #[test]
+    fn fold_assert_by_block() {
+        check(
+            r#"
+fn main() <fold block>{
+    assert(1 > 0) by <fold proof_block>{
+        assert(true);
+    }</fold>;
+}</fold>
+"#,
+        );
+    }
+
+    #[test]
+    fn fold_proof_fn_body() {
+        check(
+            r#"
+proof fn helper() 
+    requires false, 
+    ensures true,
+    <fold proof_block>{
+    assert(true);
+}</fold>
+"#,
+        );
     }
 
     #[test]

--- a/crates/rust-analyzer/src/lsp/to_proto.rs
+++ b/crates/rust-analyzer/src/lsp/to_proto.rs
@@ -780,6 +780,10 @@ pub(crate) fn folding_range(
         | FoldKind::MatchArm => None,
         FoldKind::ProofBlock => Some(lsp_types::FoldingRangeKind::Region),
     };
+    let collapsed_text = match fold.kind {
+        FoldKind::ProofBlock => Some("proof_block".to_owned()),
+        _ => None,
+    };
 
     let range = range(line_index, fold.range);
 
@@ -805,7 +809,7 @@ pub(crate) fn folding_range(
             end_line,
             end_character: None,
             kind,
-            collapsed_text: None,
+            collapsed_text,
         }
     } else {
         lsp_types::FoldingRange {
@@ -814,7 +818,7 @@ pub(crate) fn folding_range(
             end_line: range.end.line,
             end_character: Some(range.end.character),
             kind,
-            collapsed_text: None,
+            collapsed_text,
         }
     }
 }

--- a/crates/rust-analyzer/src/lsp/to_proto.rs
+++ b/crates/rust-analyzer/src/lsp/to_proto.rs
@@ -778,6 +778,7 @@ pub(crate) fn folding_range(
         | FoldKind::ReturnType
         | FoldKind::Array
         | FoldKind::MatchArm => None,
+        FoldKind::ProofBlock => Some(lsp_types::FoldingRangeKind::Region),
     };
 
     let range = range(line_index, fold.range);

--- a/editors/code/package.json
+++ b/editors/code/package.json
@@ -329,6 +329,16 @@
                 "command": "verus-analyzer.joinLines",
                 "key": "ctrl+shift+j",
                 "when": "editorTextFocus && editorLangId == rust"
+            },
+            {
+                "command": "verus-analyzer.foldProofBlocks",
+                "key": "ctrl+alt+[",
+                "when": "editorTextFocus && editorLangId == rust"
+            },
+            {
+                "command": "verus-analyzer.unfoldProofBlocks",
+                "key": "ctrl+alt+]",
+                "when": "editorTextFocus && editorLangId == rust"
             }
         ],
         "configuration": [

--- a/editors/code/package.json
+++ b/editors/code/package.json
@@ -109,6 +109,16 @@
         ],
         "commands": [
             {
+                "command": "verus-analyzer.foldProofBlocks",
+                "title": "Fold Proof Blocks",
+                "category": "verus-analyzer"
+            },
+            {
+                "command": "verus-analyzer.unfoldProofBlocks",
+                "title": "Unfold Proof Blocks",
+                "category": "verus-analyzer"
+            },
+            {
                 "command": "verus-analyzer.syntaxTree",
                 "title": "Show Syntax Tree",
                 "category": "verus-analyzer (debug command)"

--- a/editors/code/src/commands.ts
+++ b/editors/code/src/commands.ts
@@ -1520,7 +1520,7 @@ export function foldProofBlocks(ctx: Ctx): Cmd {
         if (!ranges) return;
 
         const proofRanges = ranges.filter(
-            (r) => r.kind === "proof_block" || (r.kind === "region" && r.collapsedText === "proof_block"),
+            (r) => r.kind === "region" && r.collapsedText === "proof_block",
         );
         if (proofRanges.length === 0) return;
 
@@ -1564,7 +1564,7 @@ export function unfoldProofBlocks(ctx: Ctx): Cmd {
         if (!ranges) return;
 
         const proofRanges = ranges.filter(
-            (r) => r.kind === "proof_block" || (r.kind === "region" && r.collapsedText === "proof_block"),
+            (r) => r.kind === "region" && r.collapsedText === "proof_block",
         );
         if (proofRanges.length === 0) return;
 

--- a/editors/code/src/commands.ts
+++ b/editors/code/src/commands.ts
@@ -1502,3 +1502,73 @@ export function toggleLSPLogs(ctx: Ctx): Cmd {
         }
     };
 }
+
+export function foldProofBlocks(ctx: Ctx): Cmd {
+    return async () => {
+        const editor = vscode.window.activeTextEditor;
+        if (!editor) return;
+
+        const ranges = (await ctx.client.sendRequest(
+            "textDocument/foldingRange",
+            {
+                textDocument: ctx.client.code2ProtocolConverter.asTextDocumentIdentifier(
+                    editor.document,
+                ),
+            },
+        )) as Array<vscode.FoldingRange & { kind?: string; collapsedText?: string }>;
+
+        if (!ranges) return;
+
+        const proofRanges = ranges.filter(
+            (r) => r.kind === "proof_block" || (r.kind === "region" && r.collapsedText === "proof_block"),
+        );
+        if (proofRanges.length === 0) return;
+
+        // Keep only multiline ranges and deduplicate by start line.
+        // We fold inner blocks first, then outer blocks.
+        const sortedLines = [...new Set(
+            proofRanges
+                .filter((r) => r.endLine > r.startLine)
+                .sort((a, b) => (a.endLine - a.startLine) - (b.endLine - b.startLine))
+                .map((r) => r.startLine),
+        )];
+
+        if (sortedLines.length === 0) return;
+
+        // Reset proof-block folding state before folding so repeated command runs stay
+        // idempotent and do not climb to parent fn/impl blocks.
+        await vscode.commands.executeCommand("editor.unfold", { selectionLines: sortedLines });
+
+        for (const line of sortedLines) {
+            await vscode.commands.executeCommand("editor.fold", {
+                selectionLines: [line],
+            });
+        }
+    };
+}
+
+export function unfoldProofBlocks(ctx: Ctx): Cmd {
+    return async () => {
+        const editor = vscode.window.activeTextEditor;
+        if (!editor) return;
+
+        const ranges = (await ctx.client.sendRequest(
+            "textDocument/foldingRange",
+            {
+                textDocument: ctx.client.code2ProtocolConverter.asTextDocumentIdentifier(
+                    editor.document,
+                ),
+            },
+        )) as Array<vscode.FoldingRange & { kind?: string; collapsedText?: string }>;
+
+        if (!ranges) return;
+
+        const proofRanges = ranges.filter(
+            (r) => r.kind === "proof_block" || (r.kind === "region" && r.collapsedText === "proof_block"),
+        );
+        if (proofRanges.length === 0) return;
+
+        const lines = [...new Set(proofRanges.map((r) => r.startLine))];
+        await vscode.commands.executeCommand("editor.unfold", { selectionLines: lines });
+    };
+}

--- a/editors/code/src/main.ts
+++ b/editors/code/src/main.ts
@@ -190,6 +190,8 @@ function createCommands(): Record<string, CommandFactory> {
         triggerParameterHints: { enabled: commands.triggerParameterHints },
         openLogs: { enabled: commands.openLogs },
         revealDependency: { enabled: commands.revealDependency },
+        foldProofBlocks: { enabled: commands.foldProofBlocks },
+        unfoldProofBlocks: { enabled: commands.unfoldProofBlocks },
     };
 }
 


### PR DESCRIPTION
My developer colleagues often complain that it is difficult to locate the verified executable code and the specifications among so many proof codes. Therefore, I propose this PR, which adds a command to fold proof blocks.

This PR introduces a new `FoldKind` called `ProofBlock`, along with two commands: `Fold Proof Blocks` and `Unfold Proof Blocks`. These commands fold the following constructs in VSCode:

- `proof` blocks inside `exec fn`
- `proof!` and `proof_decl!` used with `#[verus_spec]` (`proof_with!` is not included because it is usually written in a single line)
- the entire function body of a `proof fn`
- the `by` block in `assert (...) by {...};`
- the `ghost` block in `atomic_with_ghost!`

I hope it can make verified code easier to read by allowing developers to focus on the executable code and the proven properties, rather than the proof details.

<small>By submitting this pull request, I confirm that my contribution is made under the terms of the [MIT](https://github.com/verus-lang/verus-analyzer/blob/main/LICENSE-MIT) and [Apache](https://github.com/verus-lang/verus-analyzer/blob/main/LICENSE-APACHE) licenses.</small>
